### PR TITLE
[SDPA-986] Updated logo placement on mobile (remove offset on xs).

### DIFF
--- a/packages/Organisms/HeroBanner/HeroBanner.vue
+++ b/packages/Organisms/HeroBanner/HeroBanner.vue
@@ -293,8 +293,10 @@ export default {
 
     &--has-logo {
       @each $bp, $spacing in $rpl-hero-banner-vertical-spacing {
-        @include rpl_breakpoint($bp) {
-          padding-top: (map-get($spacing, top) - $rpl-hero-banner-vertical-spacing-logo-offset);
+        @if $bp != 'xs' {
+          @include rpl_breakpoint($bp) {
+            padding-top: (map-get($spacing, top) - $rpl-hero-banner-vertical-spacing-logo-offset);
+          }
         }
       }
     }

--- a/src/storybook-components/PageHeroGraphics.vue
+++ b/src/storybook-components/PageHeroGraphics.vue
@@ -17,7 +17,7 @@
     <rpl-page-layout
       :sidebar="sidebar"
       class="main rpl-container"
-      :backgroundGraphic="mock.landingPage.backgroundGraphic"
+      :backgroundGraphic="showTopGraphic ? mock.landingPage.backgroundGraphic : null"
     >
       <template slot="aboveContent">
         <rpl-breadcrumbs :crumbs="mock.breadcrumbs.crumbs" />
@@ -31,7 +31,8 @@
             { text: 'This is the fourth and final link', url: '#' }
           ]"
           :showLinks="true"
-          :backgroundGraphic="mock.heroBanner.backgroundGraphic"
+          :backgroundGraphic="showBottomGraphic ? mock.heroBanner.backgroundGraphic : null"
+          :logo="showHeroLogo ? mock.heroBanner.logo : null"
           class="rpl-site-constrain--on-all"
         />
       </template>
@@ -99,6 +100,9 @@ export default {
   },
   props: {
     sidebar: Boolean,
+    showHeroLogo: Boolean,
+    showTopGraphic: Boolean,
+    showBottomGraphic: Boolean,
     mock: Object
   },
   methods: {

--- a/src/storybook-components/stories.js
+++ b/src/storybook-components/stories.js
@@ -83,10 +83,13 @@ storiesOf('Templates', module)
   .addDecorator(withKnobs)
   .add('Landing page with hero banner graphics', () => ({
     components: { SPageHeroGraphics },
-    template: `<s-page-hero-graphics :sidebar="sidebar" :mock="mock" />`,
+    template: `<s-page-hero-graphics :sidebar="sidebar" :showHeroLogo="showHeroLogo" :showTopGraphic="showTopGraphic" :showBottomGraphic="showBottomGraphic" :mock="mock" />`,
     data () {
       return {
-        sidebar: boolean('Sidebar', true),
+        sidebar: boolean('Show Sidebar', true),
+        showHeroLogo: boolean('Show Hero Banner Logo', false),
+        showTopGraphic: boolean('Show Top Graphic', true),
+        showBottomGraphic: boolean('Show Bottom Graphic', true),
         mock: demoDataLocked
       }
     }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-

### Changed

1.  Added new controls to **Templates / Landing page with hero banner graphics** - allows graphics / logo to be toggled on and off to test different states.
2. Removed logo padding offset on xs breakpoint - this makes the Hero top padding the same for log / no logo variations at the xs breakpoint size. (Roughly placing content 20px below the Top graphic.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
![screen shot 2018-10-16 at 3 53 52 pm](https://user-images.githubusercontent.com/12739575/46993588-b6913980-d15b-11e8-818e-89d5950cef2b.png)
