### PR TITLE
[SDPA-1178] Fixed IE11 alt+tab bug. Route change removes link focus.

### DIFF
--- a/packages/Organisms/SiteHeader/index.vue
+++ b/packages/Organisms/SiteHeader/index.vue
@@ -123,10 +123,16 @@ export default {
   watch: {
     // Close menu after vue route changed.
     $route: function (to, from) {
-      if (this.menuContentOpen && this.menuState === 'opened') {
-        this.menuToggle()
-      } else if (this.menuContentOpen && this.searchState === 'opened') {
-        this.searchToggle()
+      if (this.menuContentOpen) {
+        // Remove focus on any links - this fixes a bug in IE11 [SDPA-1178].
+        document.activeElement.blur()
+
+        // Close the menu / search.
+        if (this.menuState === 'opened') {
+          this.menuToggle()
+        } else if (this.searchState === 'opened') {
+          this.searchToggle()
+        }
       }
     }
   },


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1178

### Changed

1.  Fixed IE11 alt+tab bug. Route change removes link focus.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
https://drive.google.com/file/d/1YwD-T6y28t6CaMDCDmMx5tqiLXZ8gQyt/view?usp=sharing
_Video shows before and after of blur()._
Before - shows menu on alt + tab and in console the focus is on the menu link a.
After - doesn't show menu on alt + tab and focus is on body.