### PR TITLE
[SDPA-1240] TextLink always uses external_link icon if link is external.

### DIFF
--- a/packages/Atoms/Link/TextLink.vue
+++ b/packages/Atoms/Link/TextLink.vue
@@ -35,7 +35,7 @@ export default {
   },
   computed: {
     iconSymbolFinal () {
-      if (this.iconSymbol === 'arrow_right_primary' && isExternalUrl(this.url, this.rplOptions.hostname)) {
+      if (isExternalUrl(this.url, this.rplOptions.hostname)) {
         return 'external_link'
       }
       return this.iconSymbol

--- a/packages/Molecules/RelatedLinks/index.vue
+++ b/packages/Molecules/RelatedLinks/index.vue
@@ -7,7 +7,7 @@
     <div class="rpl-related-links__row">
       <ul class="rpl-related-links__items" v-if="links">
         <li class="rpl-related-links__item" v-for="(item, index) of links" :key="index">
-          <rpl-text-link :url="item.url" icon-symbol="arrow_right_primary" icon-color="white" :text="item.text" :underline="true" size="small" theme="dark" />
+          <rpl-text-link :url="item.url" icon-color="white" :text="item.text" :underline="true" size="small" theme="dark" />
         </li>
       </ul>
     </div>

--- a/packages/Molecules/WhatsNext/index.vue
+++ b/packages/Molecules/WhatsNext/index.vue
@@ -6,7 +6,7 @@
     <div class="rpl-whats-next__row">
       <ul class="rpl-whats-next__items" v-if="links">
         <li class="rpl-whats-next__item" v-for="(item, index) of links" :key="index">
-          <rpl-text-link :url="item.url" :text="item.text" icon-symbol="arrow_right_primary" :underline="true" size="small" />
+          <rpl-text-link :url="item.url" :text="item.text" :underline="true" size="small" />
         </li>
       </ul>
     </div>


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1240

As per [comment](https://digital-engagement.atlassian.net/browse/SDPA-1240?focusedCommentId=50734&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-50734) on SDPA-1240, All external links should have an external link icon.

### Changed

1.  Made RplTextLink always use external_link icon if link is external.
1.  Removed internal link icon prop on RplTextLink in RplWhatsNext and RplRelatedLinks

### Screenshots
<img width="1346" alt="screen shot 2018-11-16 at 12 38 51 pm" src="https://user-images.githubusercontent.com/2186721/48592467-9b089100-e99c-11e8-9522-716b6cb0dd64.png">

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
