### PR TITLE
[SDPA-1077] Updated breadcrumb to sit closer to header.

### DIFF
--- a/packages/Molecules/Breadcrumbs/index.vue
+++ b/packages/Molecules/Breadcrumbs/index.vue
@@ -41,7 +41,7 @@ export default {
   $rpl-breadcrumbs-text-color: rpl-color('extra_dark_neutral') !default;
   $rpl-breadcrumbs-separator-color: rpl-color('dark_neutral') !default;
   $rpl-breadcrumbs-separator-padding: 0 ($rpl-space-2) 0 ($rpl-space) !default;
-  $rpl-breadcrumbs-items-margin: $rpl-space 0 !default;
+  $rpl-breadcrumbs-top-offset: rem(-10px) !default;
 
   .rpl-breadcrumbs {
     display: none;
@@ -50,6 +50,7 @@ export default {
     @include rpl_breakpoint('s') {
       display: block;
       margin: 0 $rpl-header-horizontal-padding-s;
+      margin-top: $rpl-breadcrumbs-top-offset;
     }
 
     &__items {
@@ -59,7 +60,7 @@ export default {
       border: $rpl-breadcrumbs-border;
       border-radius: $rpl-breadcrumbs-border-radius;
       padding: $rpl-breadcrumbs-padding;
-      margin:  $rpl-breadcrumbs-items-margin;
+      margin: 0;
       @include rpl_dropshadow;
     }
 


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1077

### Changed

1.  Updated breadcrumb to sit closer to header.

Note on implementation:
This is the least disruptive implementation to reduce breadcrumb spacing.
If breadcrumb does not display, page will render as it usually does. If breadcrumb does display, then all items below breadcrumb will sit slightly higher than they normally would.

The alternative way is to reduce the padding on `.rpl-above-content__inner`. If we do that then all items will sit slightly higher, whether breadcrumbs display or not. This means tickets like SDPA-986 will need to be redone as the logo will once again overlap the image.

I am happy to implement either way, but have chosen this way first as it's the simplest. Please let me know if you would like an alternative implementation.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
<img width="1116" alt="screen shot 2018-11-23 at 5 04 19 pm" src="https://user-images.githubusercontent.com/12739575/48930049-d88f9000-ef41-11e8-8db6-edcbff7c8965.png">
