### PR TITLE
[SDPA-1363] Removed deprecated xlink:href on svg icons.

### DIFF
--- a/packages/Atoms/Icon/Icon.vue
+++ b/packages/Atoms/Icon/Icon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg v-if="validSymbol" :class="iconClass" :style="iconStyle" aria-hidden="true">
-    <use :xlink:href="'#' + iconPrefix + symbol"></use>
+    <use :href="'#' + iconPrefix + symbol"></use>
   </svg>
 </template>
 


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1363

### Changed

1.  Changed RplIcon svg to use href instead of deprecated xlink:href attribute  - see note on https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href

Tested working in Firefox mac 63.0.3

### Screenshots

<img width="1820" alt="screen shot 2018-12-10 at 5 00 15 pm" src="https://user-images.githubusercontent.com/2186721/49713521-2c69db00-fc9d-11e8-948c-549781206436.png">

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
