### PR TITLE
[SDPSUP-99] Fixed empty anchor link section showing on Page templates

### DIFF
--- a/packages/Molecules/AnchorLinks/index.vue
+++ b/packages/Molecules/AnchorLinks/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="rpl-anchor-links">
+  <div v-if="(links.length)" class="rpl-anchor-links">
     <div class="rpl-anchor-links__row">
       <h2 class="rpl-anchor-links__title">{{ title }}</h2>
     </div>


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPSUP-99

### Changed

1.  Added checking for the anchor link element, if the array of anchor links is empty it won't render.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
<img width="980" alt="image" src="https://user-images.githubusercontent.com/37036084/52457150-84916080-2bac-11e9-9276-e618c83881e5.png">

<img width="913" alt="image" src="https://user-images.githubusercontent.com/37036084/52457163-95da6d00-2bac-11e9-9c21-03ec57095065.png">
