### PR TITLE
[SDPA-1740] Updated danger color and added hover color for quick exit button

### DIFF
--- a/packages/Atoms/Global/scss/settings/_button.scss
+++ b/packages/Atoms/Global/scss/settings/_button.scss
@@ -15,6 +15,7 @@ $rpl-button-secondary-text-color: rpl_color('white') !default;
 $rpl-button-secondary-hover-background-color: rpl_color('primary') !default;
 $rpl-button-secondary-hover-text-color: $rpl-button-secondary-text-color !default;
 $rpl-button-danger-background-color: rpl_color('danger') !default;
+$rpl-button-quickexit-hover-background-color: rpl-color('danger_light') !default;
 $rpl-button-danger-text-color: rpl_color('white') !default;
 $rpl-button-active-text-color: $rpl-button-text-color !default;
 $rpl-button-active-background-color: transparent !default;
@@ -26,3 +27,4 @@ $rpl-button-disabled-border: 1px solid rpl_color('dark_neutral') !default;
 $rpl-button-disabled-text-color: rpl_color('dark_neutral') !default;
 $rpl-narrow-button-padding-xs: $rpl-space-4 $rpl-space-4 !default;
 $rpl-narrow-button-padding-m: $rpl-space-4 ($rpl-space * 6) !default;
+

--- a/packages/Atoms/Global/scss/settings/_button.scss
+++ b/packages/Atoms/Global/scss/settings/_button.scss
@@ -15,7 +15,7 @@ $rpl-button-secondary-text-color: rpl_color('white') !default;
 $rpl-button-secondary-hover-background-color: rpl_color('primary') !default;
 $rpl-button-secondary-hover-text-color: $rpl-button-secondary-text-color !default;
 $rpl-button-danger-background-color: rpl_color('danger') !default;
-$rpl-button-quickexit-hover-background-color: rpl-color('danger_light') !default;
+$rpl-button-quick-exit-hover-background-color: lighten(rpl-color('danger'), 5%) !default;
 $rpl-button-danger-text-color: rpl_color('white') !default;
 $rpl-button-active-text-color: $rpl-button-text-color !default;
 $rpl-button-active-background-color: transparent !default;

--- a/packages/Atoms/Global/scss/settings/_color.scss
+++ b/packages/Atoms/Global/scss/settings/_color.scss
@@ -7,7 +7,8 @@ $rpl-colors: (
   'mid_neutral_1': #d7dbe0,
   'mid_neutral_2': #e8ebee,
   'light_neutral': #f6f6f9,
-  'danger': #a50034,
+  'danger': #af272f,
+  'danger_light': #d50032,
   'warning': #e35205,
   'success': #009ca6,
   'white': #fff

--- a/packages/Atoms/Global/scss/settings/_color.scss
+++ b/packages/Atoms/Global/scss/settings/_color.scss
@@ -8,8 +8,7 @@ $rpl-colors: (
   'mid_neutral_2': #e8ebee,
   'light_neutral': #f6f6f9,
   'danger': #af272f,
-  'danger_light': #d50032,
-  'warning': #e35205,
+  'warning': #ca4c21,
   'success': #009ca6,
   'white': #fff
 ) !default;

--- a/packages/Molecules/Layout/QuickExit.vue
+++ b/packages/Molecules/Layout/QuickExit.vue
@@ -129,7 +129,7 @@ export default {
       &:hover,
       &:focus {
         text-decoration: none;
-        background-color: $rpl-button-quickexit-hover-background-color;
+        background-color: $rpl-button-quick-exit-hover-background-color;
       }
     }
   }

--- a/packages/Molecules/Layout/QuickExit.vue
+++ b/packages/Molecules/Layout/QuickExit.vue
@@ -125,6 +125,12 @@ export default {
           margin-top: $rpl-quick-exit-menu-header-height-m + $rpl-quick-exit-menu-button-spacing;
         }
       }
+
+      &:hover,
+      &:focus {
+        text-decoration: none;
+        background-color: $rpl-button-quickexit-hover-background-color;
+      }
     }
   }
 </style>


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1740

### Changed

1.  Updated the danger color to match Ripple Pattern Library 1.2.0
2.  Added rollover color for quick exit button. 

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

Hover state for quick exit
![image](https://user-images.githubusercontent.com/37036084/53057683-77f1fe00-3504-11e9-85e4-47e4268415ea.png)

Updated danger color
![image 1](https://user-images.githubusercontent.com/37036084/53057820-fa7abd80-3504-11e9-91ae-9000dd1d5e72.png)


