### PR TITLE
[VICPOLUAT-117][SDPA-2049] : Adding links to the contact us block email field.

### DIFF
--- a/packages/Molecules/Contact/index.vue
+++ b/packages/Molecules/Contact/index.vue
@@ -71,6 +71,7 @@ export default {
       if (this.email) {
         _list.push({
           symbol: 'email_solid',
+          link: `mailto:${this.email}`,
           size: 0.65,
           text: this.email
         })

--- a/test/__snapshots__/storyshots.test.js.snap
+++ b/test/__snapshots__/storyshots.test.js.snap
@@ -12341,11 +12341,12 @@ exports[`RippleStoryshots Molecules/Contact Contact 1`] = `
               <!---->
             </span>
              
-            <span
-              class="rpl-list__text"
+            <a
+              class="rpl-link rpl-list__text"
+              href="mailto:emailaddress@vic.gov.au"
             >
               emailaddress@vic.gov.au
-            </span>
+            </a>
           </div>
           <div
             class="rpl-list__list-item"
@@ -39956,11 +39957,12 @@ exports[`RippleStoryshots Templates Landing page demo 1`] = `
                       <!---->
                     </span>
                      
-                    <span
-                      class="rpl-list__text"
+                    <a
+                      class="rpl-link rpl-list__text"
+                      href="mailto:emailaddress@vic.gov.au"
                     >
                       emailaddress@vic.gov.au
-                    </span>
+                    </a>
                   </div>
                   <div
                     class="rpl-list__list-item"
@@ -46678,11 +46680,12 @@ exports[`RippleStoryshots Templates Profile Page 1`] = `
                       <!---->
                     </span>
                      
-                    <span
-                      class="rpl-list__text"
+                    <a
+                      class="rpl-link rpl-list__text"
+                      href="mailto:emailaddress@vic.gov.au"
                     >
                       emailaddress@vic.gov.au
-                    </span>
+                    </a>
                   </div>
                   <div
                     class="rpl-list__list-item"


### PR DESCRIPTION
### Changed

1.  Adding links to the contact us block email field.

### Screenshots
<img width="276" alt="screen shot 2019-02-21 at 22 08 18" src="https://user-images.githubusercontent.com/13358666/53164849-4c1a6980-3625-11e9-8867-abdb19f19907.png">
