### PR TITLE
[SDPA-2051] Replace view height to fix ios safari issues.

### DIFF
--- a/packages/Organisms/SiteHeader/index.vue
+++ b/packages/Organisms/SiteHeader/index.vue
@@ -327,7 +327,7 @@ export default {
     &--open {
       position: fixed;
       top: 0;
-      height: 100vh;
+      height: 100%;
 
       #{$root}__inner {
         margin: 0;
@@ -395,7 +395,7 @@ export default {
       &--vertical {
         width: auto;
         position: absolute;
-        bottom: 0;
+        bottom: $rpl-header-horizontal-padding-xs;
         left: $rpl-header-horizontal-padding-xs;
         right: $rpl-header-horizontal-padding-xs;
         overflow-x: hidden;


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2051

### Changed

1.  Fix for ios safari issue with 100vh and the bottom bar - https://nicolas-hoizey.com/2015/02/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers.html Replaces vh with %. 

### Screenshots
![screenrecording20190226at9](https://user-images.githubusercontent.com/2186721/53372349-b9702680-39a6-11e9-8785-48fc0b352363.gif)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
