### PR TITLE
[SDPA-1946] Add checks to prevent missing link text from throwing error.

### DIFF
--- a/packages/Molecules/Card/CardEvent.vue
+++ b/packages/Molecules/Card/CardEvent.vue
@@ -43,10 +43,10 @@ export default {
   },
   methods: {
     getTrimFieldMaxHeightOffset: function (card) {
-      let link = this.$el.querySelector('.rpl-card-content__link')
-      let location = this.$el.querySelector('.rpl-card-event__location')
-      let rtnMaxHeight = card.clientHeight - link.clientHeight
-      return (location) ? (rtnMaxHeight - location.clientHeight) : rtnMaxHeight
+      const link = this.$el.querySelector('.rpl-card-content__link')
+      const location = this.$el.querySelector('.rpl-card-event__location')
+      const rtnMaxHeight = link ? (card.clientHeight - link.clientHeight) : card.clientHeight
+      return location ? (rtnMaxHeight - location.clientHeight) : rtnMaxHeight
     }
   },
   computed: {

--- a/packages/Molecules/Card/CardPromotion.vue
+++ b/packages/Molecules/Card/CardPromotion.vue
@@ -39,8 +39,8 @@ export default {
   },
   methods: {
     getTrimFieldMaxHeightOffset: function (card) {
-      let link = this.$el.querySelector('.rpl-card-content__link')
-      return (card.clientHeight - link.clientHeight)
+      const link = this.$el.querySelector('.rpl-card-content__link')
+      return link ? (card.clientHeight - link.clientHeight) : card.clientHeight
     }
   }
 }

--- a/packages/Molecules/Card/mixins/cardtrimfield.js
+++ b/packages/Molecules/Card/mixins/cardtrimfield.js
@@ -15,6 +15,12 @@ const cardtrimfield = {
     }
   },
   methods: {
+    /**
+     * Return trimmed field's bottom-most position (in pixels) from top of card.
+     * Value will be subtracted from field's top position to get field height.
+     * Override if elements below trimmed field will affect the available space.
+     * @param {Object} card The HTML element for the card.
+     */
     getTrimFieldMaxHeightOffset: function (card) {
       return card.clientHeight
     },


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1946

### Changed

* Add checks to prevent missing link text from throwing error.
* Can occur for promotion and event cards.
* Added comment to explain purpose of getTrimFieldMaxHeightOffset function.

Looks like there are checks in the calling function to prevent a null card from being passed to the getTrimFieldMaxHeightOffset function. These issues are appear to be due to the overridden getTrimFieldMaxHeightOffset() functions in Promotions and Events not including null checks for CTA text (the 'Read More' text at the bottom of the card). If a link is defined, but the text is null, then this issue would occur.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
No screenshot.