### PR TITLE
[SDPA-1900] Card Carousel props added to define cards to show.

### DIFF
--- a/packages/Atoms/Global/mixins/breakpoint.js
+++ b/packages/Atoms/Global/mixins/breakpoint.js
@@ -24,33 +24,29 @@ const breakpoint = {
   data () {
     return {
       clientWidth: 0,
-      clientHeight: 0
+      clientHeight: 0,
+      breakpointsSmallToLarge: [
+        { label: 'xs', value: 0 },
+        { label: 's', value: 576 },
+        { label: 'm', value: 768 },
+        { label: 'l', value: 992 },
+        { label: 'xl', value: 1200 },
+        { label: 'xxl', value: 1600 },
+        { label: 'xxxl', value: 2560 }
+      ]
     }
   },
   computed: {
     $breakpoint () {
-      const xs = this.clientWidth >= 0
-      const s = this.clientWidth >= 576
-      const m = this.clientWidth >= 768
-      const l = this.clientWidth >= 992
-      const xl = this.clientWidth >= 1200
-      const xxl = this.clientWidth >= 1600
-      const xxxl = this.clientWidth >= 2560
-
       const result = {
-        // Definite breakpoint.
-        'xs': xs,
-        's': s,
-        'm': m,
-        'l': l,
-        'xl': xl,
-        'xxl': xxl,
-        'xxxl': xxxl,
-
         // For custom breakpoint logic.
         'width': this.clientWidth,
         'height': this.clientHeight
       }
+      // Define breakpoints.
+      this.breakpointsSmallToLarge.forEach(bp => {
+        result[bp.label] = (this.clientWidth >= bp.value)
+      })
       return result
     }
   },

--- a/packages/Molecules/Card/no-ssr/CardCarousel.vue
+++ b/packages/Molecules/Card/no-ssr/CardCarousel.vue
@@ -44,7 +44,9 @@ export default {
     title: String,
     cards: Array,
     previousLabel: { type: String, default: 'Go to previous slide' },
-    nextLabel: { type: String, default: 'Go to next slide' }
+    nextLabel: { type: String, default: 'Go to next slide' },
+    colsBp: { type: Object },
+    totalGridColumns: { type: Number, default: 12 }
   },
   components: {
     RplIcon,
@@ -93,13 +95,14 @@ export default {
   },
   computed: {
     slidesPerPage () {
-      if (this.$breakpoint.l) {
-        return 3
-      } else if (this.$breakpoint.m) {
-        return 2
-      } else {
-        return 1
+      // Determine # of cards to display based on defined column breakpoints.
+      for (let i = this.breakpointsSmallToLarge.length - 1; i >= 0; i--) {
+        const bp = this.breakpointsSmallToLarge[i].label
+        if (this.colsBp[bp] && this.$breakpoint[bp]) {
+          return this.totalGridColumns / this.colsBp[bp]
+        }
       }
+      return 1
     },
     totalSlides () {
       return Math.ceil(this.cards.length / this.slidesPerPage) - 1

--- a/packages/Molecules/Card/no-ssr/CardCarousel.vue
+++ b/packages/Molecules/Card/no-ssr/CardCarousel.vue
@@ -45,7 +45,7 @@ export default {
     cards: Array,
     previousLabel: { type: String, default: 'Go to previous slide' },
     nextLabel: { type: String, default: 'Go to next slide' },
-    colsBp: { type: Object },
+    colsBp: { type: Object, default: () => ({ l: 4, m: 6 }) },
     totalGridColumns: { type: Number, default: 12 }
   },
   components: {
@@ -95,11 +95,13 @@ export default {
   },
   computed: {
     slidesPerPage () {
-      // Determine # of cards to display based on defined column breakpoints.
-      for (let i = this.breakpointsSmallToLarge.length - 1; i >= 0; i--) {
-        const bp = this.breakpointsSmallToLarge[i].label
-        if (this.colsBp[bp] && this.$breakpoint[bp]) {
-          return this.totalGridColumns / this.colsBp[bp]
+      if (this.colsBp && this.totalGridColumns) {
+        // Determine # of cards to display based on defined column breakpoints.
+        for (let i = this.breakpointsSmallToLarge.length - 1; i >= 0; i--) {
+          const bp = this.breakpointsSmallToLarge[i].label
+          if (this.colsBp[bp] && this.$breakpoint[bp]) {
+            return this.totalGridColumns / this.colsBp[bp]
+          }
         }
       }
       return 1

--- a/packages/Molecules/Card/stories.js
+++ b/packages/Molecules/Card/stories.js
@@ -114,7 +114,7 @@ storiesOf('Molecules/Card', module)
   })))
   .add('Card Carousel', withReadme(readme, () => ({
     components: { RplCardCarousel },
-    template: `<rpl-card-carousel :title="title" :cards="cards" />`,
+    template: `<rpl-card-carousel :title="title" :cards="cards" :colsBp="colsBp" :totalGridColumns="totalGridColumns" />`,
     data () {
       return demoData.cardCarousel()
     }

--- a/src/storybook-components/Page.vue
+++ b/src/storybook-components/Page.vue
@@ -62,7 +62,7 @@
           <rpl-anchor-links :title="mock.anchorLinks.title" :links="mock.anchorLinks.links" />
         </rpl-col>
         <rpl-col v-if="!sidebar" cols="full" :colsBp="defaultCols">
-          <rpl-card-carousel :title="mock.cardCarousel.title" :cards="mock.cardCarousel.cards" />
+          <rpl-card-carousel v-bind="mock.cardCarousel" />
         </rpl-col>
         <rpl-col cols="full" :colsBp="defaultCols">
           <rpl-card-navigation-featured v-bind="mock.cardNavigationFeatured" />
@@ -96,7 +96,7 @@
           </div>
         </rpl-col>
         <rpl-col cols="full">
-          <rpl-card-carousel v-bind="mock.cardCarousel" />
+          <rpl-card-carousel v-bind="mock.cardCarousel" :colsBp="sidebar ? mock.siteLayout.cardColsWithSidebar : mock.siteLayout.cardCols" />
         </rpl-col>
         <rpl-col cols="full" :colsBp="defaultCols">
           <rpl-image-gallery :gallery-data="mock.imageGallery.gallery" :enlarge-text="mock.imageGallery.enlargeText" />

--- a/src/storybook-components/_data/demoData.js
+++ b/src/storybook-components/_data/demoData.js
@@ -429,7 +429,9 @@ const demoData = {
           link: { text: 'See the events calendar', url: '#' }
         }
       }
-    ])
+    ]),
+    colsBp: object('Column breakpoints', { l: 4, m: 6 }),
+    totalGridColumns: number('Total grid columns', 12)
   }),
 
   relatedLinks: () => ({

--- a/test/__snapshots__/storyshots.test.js.snap
+++ b/test/__snapshots__/storyshots.test.js.snap
@@ -7610,6 +7610,30 @@ exports[`RippleStoryshots Molecules/Card Card Carousel 1`] = `
           >
             "cards"
           </span>
+           
+          <span
+            class="hljs-attr"
+          >
+            :colsBp
+          </span>
+          =
+          <span
+            class="hljs-string"
+          >
+            "colsBp"
+          </span>
+           
+          <span
+            class="hljs-attr"
+          >
+            :totalGridColumns
+          </span>
+          =
+          <span
+            class="hljs-string"
+          >
+            "totalGridColumns"
+          </span>
            /&gt;
         </span>
       </code>
@@ -7797,6 +7821,73 @@ exports[`RippleStoryshots Molecules/Card Card Carousel 1`] = `
             data-v-5bd9cdea=""
           >
             Go to next slide
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+        </tr>
+        <tr
+          class="props-table-row"
+          data-v-5bd9cdea=""
+          data-v-91bb5cde=""
+        >
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+    colsBp
+    
+            <!---->
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            object
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            {
+  "l": 4,
+  "m": 6
+}
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+        </tr>
+        <tr
+          class="props-table-row"
+          data-v-5bd9cdea=""
+          data-v-91bb5cde=""
+        >
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+    totalGridColumns
+    
+            <!---->
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            number
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            12
           </td>
            
           <td


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1900

### Changed

1.  Card Carousel props added to define cards to show.

This change allows a new colsBp prop to be passed to RplCardCarousel. The colsBp matches the same way breakpoints on <rpl-col /> elements are defined. This means the same object can be used for RplCol and RplCardCarousel.
This required a change to the breakpoint mixin to expose the available breakpoints as an ordered array. This allows the card carousel to pick the largest enabled breakpoint from the list and determine how many cards to show by dividing by the total cols (a new prop as well).

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
![screen shot 2019-02-27 at 13 29 29-fullpage](https://user-images.githubusercontent.com/12739575/53461164-ca4a9600-3a93-11e9-9c3b-55f9cb7f1880.png)
![screen shot 2019-02-27 at 13 28 53-fullpage](https://user-images.githubusercontent.com/12739575/53461165-ca4a9600-3a93-11e9-8a0f-12c9fe573682.png)
![screen shot 2019-02-27 at 13 28 44-fullpage](https://user-images.githubusercontent.com/12739575/53461166-cae32c80-3a93-11e9-8c8f-6ca805cab461.png)
![screen shot 2019-02-27 at 13 28 35-fullpage](https://user-images.githubusercontent.com/12739575/53461167-cae32c80-3a93-11e9-809d-fdfa62c16834.png)