### PR TITLE
[SDPA-1658] Fix h2 top margin when there is something above it.

### DIFF
--- a/packages/Organisms/Markup/Markup.vue
+++ b/packages/Organisms/Markup/Markup.vue
@@ -49,7 +49,7 @@ export default {
 .rpl-markup {
 
   &__inner {
-    > h2:first-of-type {
+    > h2:first-child {
       margin-top: 0;
     }
   }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1658

### Changed

1.  Change selector from .rpl-markup__inner>h2:first-of-type to .rpl-markup__inner>h2:first-child

### Screenshots

**After**
<img width="741" alt="screen shot 2019-03-06 at 4 08 47 pm" src="https://user-images.githubusercontent.com/2186721/53857417-50358680-402a-11e9-97c6-0f2cc3bba360.png">

**Before**
<img width="769" alt="screen shot 2019-03-06 at 4 09 06 pm" src="https://user-images.githubusercontent.com/2186721/53857427-59265800-402a-11e9-95f2-4956eb383d03.png">

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
