### PR TITLE
[SDPA-2252] Improved site section navi menu accessibility

### DIFF
--- a/packages/Organisms/SiteSectionNavigation/menu.vue
+++ b/packages/Organisms/SiteSectionNavigation/menu.vue
@@ -219,7 +219,7 @@ export default {
           background-color: $rpl-section-menu-first-level-item-background-color;
         }
         #{$root}__item-link {
-          padding-left: $rpl-section-menu-item-left-padding + rem(1 * 16px);
+          padding-left: $rpl-section-menu-item-left-padding + $rpl-space-4;
         }
       }
 
@@ -239,7 +239,7 @@ export default {
 
         }
         #{$root}__item-link {
-          padding-left: $rpl-section-menu-item-left-padding + rem(2 * 16px);
+          padding-left: $rpl-section-menu-item-left-padding + ($rpl-space-4 * 2);
         }
       }
 
@@ -256,7 +256,7 @@ export default {
         }
 
         #{$root}__item-link {
-          padding-left: $rpl-section-menu-item-left-padding + rem(3 * 16px);
+          padding-left: $rpl-section-menu-item-left-padding + ($rpl-space-4 * 3);
         }
       }
 

--- a/packages/Organisms/SiteSectionNavigation/menu.vue
+++ b/packages/Organisms/SiteSectionNavigation/menu.vue
@@ -72,7 +72,7 @@ export default {
   $rpl-section-menu-link-ruleset: ('xs', 1em, 'medium') !default;
   $rpl-section-menu-link-sub-ruleset: ('xs', 1em, 'medium') !default;
   $rpl-section-menu-item-background-color: rpl_color('primary') !default;
-  $rpl-section-menu-item-link-padding: $rpl-space-4 $rpl-component-padding-s !default;
+  $rpl-section-menu-item-link-padding: $rpl-space-4 ($rpl-space * 6) !default;
   $rpl-section-menu-item-link-color: rpl_color('white') !default;
   $rpl-section-menu-item-link-parent-hover-background-color: rpl_color('primary') !default;
   $rpl-section-menu-item-link-parent-hover-background-image: rpl_gradient('primary_gradient') !default;
@@ -82,10 +82,10 @@ export default {
   $rpl-section-menu-item-link-active-border: $rpl-section-menu-item-link-active-border-height solid rpl_color('dark_primary') !default;
   $rpl-section-menu-first-level-background: rpl_color('primary') !default;
   $rpl-section-menu-first-level-item-background-color: rpl_color('dark_primary') !default;
-  $rpl-section-menu-item-link-parent-text-margin: 0 ($rpl-space * 5) 0 0 !default;
+  $rpl-section-menu-item-link-parent-text-margin: 0 ($rpl-space * 5) 0 0 !default; //update parent title to have 24px margin up from 20px.
   $rpl-section-menu-item-link-parent-icon-min-width: rem(8px) !default;
   $rpl-section-menu-item-indent-padding: rem(13px) !default;
-  $rpl-section-menu-item-link-active-text-color: mix(rpl-color('white'), rpl-color('primary'), 65%) !default;
+  $rpl-section-menu-item-link-active-text-color: rpl-color('white') !default;
   $rpl-section-menu-active-left-bar: url('data:image/svg+xml,%3Csvg%20width%3D%224%22%20height%3D%221%22%20viewBox%3D%220%200%204%201%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%224%22%20height%3D%221%22%20fill%3D%22%23#{str-slice(quote(rpl_color("secondary")), 2)}%22%2F%3E%3C%2Fsvg%3E') !default;
 
   @mixin rpl-section-menu-active-left-border {
@@ -210,11 +210,16 @@ export default {
     }
 
     &[data-depth="1"] {
+
       #{$root}__item {
         &::before {
+          top: 90px;
           left: $rpl-component-padding-s;
           right: $rpl-component-padding-s;
           background-color: $rpl-section-menu-first-level-item-background-color;
+        }
+        #{$root}__item-link {
+          padding-left: ($rpl-space * 6) + rem(1 * 16px);
         }
       }
 
@@ -231,6 +236,10 @@ export default {
       #{$root}__item {
         &::before {
           display: none;
+
+        }
+        #{$root}__item-link {
+          padding-left: ($rpl-space * 6) + rem(2 * 16px);
         }
       }
 

--- a/packages/Organisms/SiteSectionNavigation/menu.vue
+++ b/packages/Organisms/SiteSectionNavigation/menu.vue
@@ -70,9 +70,10 @@ export default {
   @import "~@dpc-sdp/ripple-global/scss/tools";
 
   $rpl-section-menu-link-ruleset: ('xs', 1em, 'medium') !default;
-  $rpl-section-menu-link-sub-ruleset: ('xs', 1em, 'medium') !default;
+  $rpl-section-menu-link-sub-ruleset: ('xs', 1em, 'regular') !default;
   $rpl-section-menu-item-background-color: rpl_color('primary') !default;
-  $rpl-section-menu-item-link-padding: $rpl-space-4 ($rpl-space * 6) !default;
+  $rpl-section-menu-item-left-padding: ($rpl-space * 6) !default;
+  $rpl-section-menu-item-link-padding: $rpl-space-4 $rpl-section-menu-item-left-padding !default;
   $rpl-section-menu-item-link-color: rpl_color('white') !default;
   $rpl-section-menu-item-link-parent-hover-background-color: rpl_color('primary') !default;
   $rpl-section-menu-item-link-parent-hover-background-image: rpl_gradient('primary_gradient') !default;
@@ -82,7 +83,7 @@ export default {
   $rpl-section-menu-item-link-active-border: $rpl-section-menu-item-link-active-border-height solid rpl_color('dark_primary') !default;
   $rpl-section-menu-first-level-background: rpl_color('primary') !default;
   $rpl-section-menu-first-level-item-background-color: rpl_color('dark_primary') !default;
-  $rpl-section-menu-item-link-parent-text-margin: 0 ($rpl-space * 5) 0 0 !default; //update parent title to have 24px margin up from 20px.
+  $rpl-section-menu-item-link-parent-text-margin: 0 ($rpl-space * 5) 0 0 !default;
   $rpl-section-menu-item-link-parent-icon-min-width: rem(8px) !default;
   $rpl-section-menu-item-indent-padding: rem(13px) !default;
   $rpl-section-menu-item-link-active-text-color: rpl-color('white') !default;
@@ -213,13 +214,12 @@ export default {
 
       #{$root}__item {
         &::before {
-          top: 90px;
           left: $rpl-component-padding-s;
           right: $rpl-component-padding-s;
           background-color: $rpl-section-menu-first-level-item-background-color;
         }
         #{$root}__item-link {
-          padding-left: ($rpl-space * 6) + rem(1 * 16px);
+          padding-left: $rpl-section-menu-item-left-padding + rem(1 * 16px);
         }
       }
 
@@ -239,7 +239,7 @@ export default {
 
         }
         #{$root}__item-link {
-          padding-left: ($rpl-space * 6) + rem(2 * 16px);
+          padding-left: $rpl-section-menu-item-left-padding + rem(2 * 16px);
         }
       }
 
@@ -253,6 +253,10 @@ export default {
       #{$root}__item {
         &::before {
           display: none;
+        }
+
+        #{$root}__item-link {
+          padding-left: $rpl-section-menu-item-left-padding + rem(3 * 16px);
         }
       }
 


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2252

### Changed

1.  Headings for site section navigation are now always coloured #fff
2. Each menu level will have a left padding of its parent + 16px, up to three levels deep.
3. First level menu item now has left padding of 24px. 
4. Third menu level uses VIC-Regular font instead of VIC-Medium

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

Ripple component design:

<img width="645" alt="Screen Shot 2019-03-21 at 10 15 57 am" src="https://user-images.githubusercontent.com/37036084/54729931-31aebe00-4bda-11e9-8066-3e55559b6653.png">

Site section navigation now passes AA and AAA contrast validation:

<img width="1423" alt="Screen Shot 2019-03-21 at 1 04 01 pm" src="https://user-images.githubusercontent.com/37036084/54729953-4f7c2300-4bda-11e9-8f07-384e97aaec57.png">

