### PR TITLE
[SDPA-2437] Fix image gallery height in modal.

### DIFF
--- a/packages/Organisms/ImageGallery/ImageGallery.vue
+++ b/packages/Organisms/ImageGallery/ImageGallery.vue
@@ -451,7 +451,9 @@ export default {
       .VueCarousel,
       .VueCarousel-wrapper,
       .VueCarousel-inner {
-        height: 100%;
+        // Force 100% height to override inline auto height introduced in:
+        // https://github.com/SSENSE/vue-carousel/commit/f1e631427f533b5f7846f95fa7099abd818e1683
+        height: 100% !important; // sass-lint:disable-line no-important
       }
     }
   }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2437

### Changed

1.  Fix image gallery height in modal.

Force 100% height to override inline auto height introduced in:
https://github.com/SSENSE/vue-carousel/commit/f1e631427f533b5f7846f95fa7099abd818e1683

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
![Screen Shot 2019-04-18 at 12 02 50-fullpage](https://user-images.githubusercontent.com/12739575/56332006-eafcb580-61d1-11e9-966a-2a37e038b0a6.png)
