### PR TITLE
Documentation script update.

### DIFF
--- a/scripts/generate-readme/README_template.md
+++ b/scripts/generate-readme/README_template.md
@@ -27,6 +27,14 @@ npm install {{ packageName }} --save
 {{ packageImports }}
 ```
 
+{% if noSsrPackageImports %}
+## Import for client-only components
+
+```js
+{{ noSsrPackageImports }}
+```
+
+{% endif %}
 --------------------------------------------------------------------------------
 
 ## Usage and Tests

--- a/scripts/generate-readme/generate-readme.js
+++ b/scripts/generate-readme/generate-readme.js
@@ -70,7 +70,7 @@ function generateTemplate (directory) {
   let storiesOf = /(?:storiesOf\(')(.+)(?:',)/g
   let storiesOfMatch = storiesOf.exec(story)
 
-  let add = /(?:add\(')(.+)(?:',)/gim
+  let add = /(?:add\([\n\s]*)(?:')(.+)(?:',)/gim
   let addMatch = add.exec(story)
   while (addMatch !== null) {
     data.storybookParams.push({
@@ -79,6 +79,8 @@ function generateTemplate (directory) {
     })
     addMatch = add.exec(story)
   }
+
+  // Add check for no-ssr folder.
 
   // Render template.
   Twig.renderFile(path.join(__dirname, '/README_template.md'), data, (err, html) => {

--- a/scripts/generate-readme/get-imports.js
+++ b/scripts/generate-readme/get-imports.js
@@ -1,7 +1,6 @@
 let fs = require('fs')
 
 function getImportStatements (pkgdirectory) {
-  const importStatements = []
   const pkg = fs.readFileSync(pkgdirectory, 'utf-8')
   const packageData = JSON.parse(pkg)
   const packageMain = packageData.main
@@ -9,40 +8,50 @@ function getImportStatements (pkgdirectory) {
   const importedFile = fs.readFileSync(pkgdirectory.replace('package.json', packageMain), 'utf-8')
 
   if (packageMain.indexOf('.js') > -1) {
-    const reg = new RegExp('export\\s({|default)\\s*([A-Za-z]+)', 'gi')
-    const batchCurlies = []
-    let importDefault = null
-
-    // Match
-    let lastMatch = reg.exec(importedFile)
-    while (lastMatch !== null) {
-      if (lastMatch && lastMatch.length === 3) {
-        const type = lastMatch[1]
-        const name = lastMatch[2]
-        if (type === '{') {
-          batchCurlies.push(name)
-        } else {
-          importDefault = name
-        }
-      }
-      lastMatch = reg.exec(importedFile)
-    }
-    // Add to array
-    if (batchCurlies.length > 0) {
-      importStatements.push(`import { ${batchCurlies.toString().replace(/,/gi, ', ')} } from '${packageName}'`)
-    }
-    if (importDefault !== null && batchCurlies.indexOf(importDefault) < 0) {
-      importStatements.push(`import ${importDefault} from '${packageName}'`)
-    }
+    return getImportStatementFromJS(importedFile, packageName)
   } else {
     // Assume a .vue file.
+    const importStatements = []
     const reg = new RegExp('name: \'(.*)\'', 'gi')
     let lastMatch = reg.exec(importedFile)
     if (lastMatch !== null) {
       importStatements.push(`import ${lastMatch[1]} from '${packageName}'`)
     }
+    return importStatements
+  }
+}
+
+function getImportStatementFromJS (importedFile, packageName) {
+  const importStatements = []
+  const reg = new RegExp('export\\s({|default)\\s*([A-Za-z]+)', 'gi')
+  const batchCurlies = []
+  let importDefault = null
+
+  // Match
+  let lastMatch = reg.exec(importedFile)
+  while (lastMatch !== null) {
+    if (lastMatch && lastMatch.length === 3) {
+      const type = lastMatch[1]
+      const name = lastMatch[2]
+      if (type === '{') {
+        batchCurlies.push(name)
+      } else {
+        importDefault = name
+      }
+    }
+    lastMatch = reg.exec(importedFile)
+  }
+  // Add to array
+  if (batchCurlies.length > 0) {
+    importStatements.push(`import { ${batchCurlies.toString().replace(/,/gi, ', ')} } from '${packageName}'`)
+  }
+  if (importDefault !== null && batchCurlies.indexOf(importDefault) < 0) {
+    importStatements.push(`import ${importDefault} from '${packageName}'`)
   }
   return importStatements
 }
 
-module.exports = getImportStatements
+module.exports = {
+  getImportStatements: getImportStatements,
+  getImportStatementFromJS: getImportStatementFromJS
+}


### PR DESCRIPTION
Implements:
1. Support for linebreaks in the stories.add() feature for cases such as:
```
  .add(
    'Icon Library',
    withReadme(readme, () => ({
      components: { SIcons },
      template: '<s-icons :icons="icons" :color="color" :size="size" />',
      data () {
        return demoData.iconLibrary()
      }
    }))
  )
```
will output as:

```
See [Storybook/Icon Library](https://ripple.sdp.vic.gov.au/?selectedKind=Atoms/Icon&selectedStory=Icon%20Library).
```

2. Includes import statements for components defined in no-ssr/index.js files. Such as RplImageGallery and RplCardCarousel:
```
--------------------------------------------------------------------------------

## Import

import {
  RplImageGalleryModal,
  RplFullscreenImage
} from '@dpc-sdp/ripple-image-gallery'

## Import for client-only components

import { RplImageGallery } from '@dpc-sdp/ripple-image-gallery/no-ssr'

--------------------------------------------------------------------------------
```