### PR TITLE
[SDPA-2629] Remove breakpoint mixin for pagination and set padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@types/node": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-      "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+      "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -2125,9 +2125,9 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
-      "integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.0.tgz",
+      "integrity": "sha512-6hrXm6NIoSp+JiqhHZ6tUemhClnu//vjx9fAU5tkRCztTKxgiUpFpMDBX4yZiJIco7qkf0CPX2u4Ax3x6GCiUg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.2",
@@ -5544,9 +5544,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.138",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.138.tgz",
-      "integrity": "sha512-V6gvA2zuVp2l8gT8tvaFp3z2IOnx0UeCPuG6Fyw4x/eZEbt9xD9npSgia6emmDFHAz3TU0bElnpKZ3xZ0CUNDw==",
+      "version": "1.3.143",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.143.tgz",
+      "integrity": "sha512-J9jOpxIljQZlV6GIP2fwAWq0T69syawU0sH3EW3O2Bgxquiy+veeIT5mBDRz+i3oHUSL1tvVgRKH3/4QiQh9Pg==",
       "dev": true
     },
     "elliptic": {
@@ -7799,9 +7799,9 @@
       "dev": true
     },
     "fuse.js": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.4.tgz",
-      "integrity": "sha512-pyLQo/1oR5Ywf+a/tY8z4JygnIglmRxVUOiyFAbd11o9keUDpUJSMGRWJngcnkURj30kDHPmhoKY8ChJiz3EpQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.5.tgz",
+      "integrity": "sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ==",
       "dev": true
     },
     "gauge": {
@@ -8232,7 +8232,7 @@
         "is-windows": "^0.1.0",
         "kind-of": "^2.0.0",
         "lazy-cache": "^0.1.0",
-        "micromatch": "github:jonschlinkert/micromatch#5017fd78202e04c684cc31d3c2fb1f469ea222ff",
+        "micromatch": "github:jonschlinkert/micromatch#b0ac0b7cea8d90f97630c027d0116a8aef06bfdc",
         "mixin-object": "^2.0.0",
         "object-visit": "^0.1.0",
         "object.omit": "^1.1.0",
@@ -8384,7 +8384,7 @@
           }
         },
         "micromatch": {
-          "version": "github:jonschlinkert/micromatch#5017fd78202e04c684cc31d3c2fb1f469ea222ff",
+          "version": "github:jonschlinkert/micromatch#b0ac0b7cea8d90f97630c027d0116a8aef06bfdc",
           "from": "github:jonschlinkert/micromatch#2.2.0",
           "dev": true,
           "requires": {
@@ -8741,9 +8741,9 @@
       },
       "dependencies": {
         "uglify-js": {
-          "version": "3.5.15",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
-          "integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+          "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -20887,9 +20887,9 @@
       }
     },
     "vue-social-sharing": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/vue-social-sharing/-/vue-social-sharing-2.4.4.tgz",
-      "integrity": "sha512-do0ig12rG173V14s+dz1B6K5I9BmMGZfcHMGnZHTKFaIoAWZVeIykEh+XnwaTpFYx2lW1om7XAj3qb08x9PVPQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/vue-social-sharing/-/vue-social-sharing-2.4.5.tgz",
+      "integrity": "sha512-6hZ1fcHdDPLzpvd44yt+3DOCfUiqAAiFQF+odhdpFQ5MU3HJ2eofD0UZqgwPLP08duYuNesx+ntldAZG4GV5Xw==",
       "requires": {
         "vue": "^2.2.4"
       }

--- a/packages/Molecules/Layout/PageLayout.vue
+++ b/packages/Molecules/Layout/PageLayout.vue
@@ -1,6 +1,5 @@
 <template>
-  <main class="rpl-page">
-
+  <main class="rpl-page" :class="{'rpl-page--with-search': withSearch }">
     <section
       class="rpl-above-content-container"
       :class="{ 'rpl-above-content-container--with-bg': heroBackgroundImage }"
@@ -69,7 +68,8 @@ export default {
     'quickExit': { type: Boolean, default: null },
     'backgroundColor': String,
     'heroBackgroundImage': String,
-    'backgroundGraphic': String
+    'backgroundGraphic': String,
+    'withSearch': Boolean
   },
   data () {
     return {
@@ -109,9 +109,10 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import "~@dpc-sdp/ripple-global/scss/settings";
 @import "~@dpc-sdp/ripple-global/scss/tools";
+$rpl-search-back-to-top-offset: 72px / 2;
 
 .rpl-above-content {
   background-repeat: no-repeat;
@@ -214,6 +215,20 @@ export default {
     width: 100%;
     margin: 0;
     left: 0;
+  }
+}
+
+.rpl-page--with-search {
+  .rpl-pagination {
+    // Allow half of back to top buttom (72px) in BaseLayout.
+    padding-bottom: $rpl-search-back-to-top-offset;
+    @include rpl_breakpoint('s') {
+      padding-bottom: 0;
+    }
+
+    @include rpl_breakpoint(m) {
+      width: 100%;
+    }
   }
 }
 

--- a/packages/Molecules/Pagination/index.vue
+++ b/packages/Molecules/Pagination/index.vue
@@ -118,7 +118,8 @@ export default {
   $rpl-pagination-step-hover-border-bottom: 2px solid rpl-color('secondary') !default;
   $rpl-pagination-step-current-color: rpl-color('secondary') !default;
   $rpl-pagination-step-current-border-bottom: 2px solid rpl-color('secondary') !default;
-  $rpl-pagination-nav-margin: 0 0 0 ($rpl-space * 6) !default;
+  $rpl-pagination-nav-margin: 0 0 0 ($rpl-space) !default;
+  $rpl-pagination-nav-padding: $rpl-space-2 !default;
 
   .rpl-pagination {
     display: flex;
@@ -189,13 +190,13 @@ export default {
 
     &__controls {
       margin-left: auto;
-      margin-right: 0;
+      margin-right: -$rpl-space;
     }
 
     &__nav {
       background: transparent;
       border: 0;
-      padding: 0;
+      padding: $rpl-pagination-nav-padding;
       margin: $rpl-pagination-nav-margin;
       cursor: pointer;
       span {

--- a/packages/Molecules/Pagination/index.vue
+++ b/packages/Molecules/Pagination/index.vue
@@ -29,7 +29,6 @@
 
 <script>
 import RplIcon from '@dpc-sdp/ripple-icon'
-import breakpoint from '@dpc-sdp/ripple-global/mixins/breakpoint'
 
 export default {
   name: 'RplPagination',
@@ -46,7 +45,6 @@ export default {
     initialStep: { type: Number, default: 1 },
     stepsAround: { type: Number, default: 2 }
   },
-  mixins: [breakpoint],
   components: {
     RplIcon
   },
@@ -70,17 +68,7 @@ export default {
   computed: {
     visibleStepRange () {
       // Returns Array or Number of visible steps.
-      let visibleCount = this.stepsAround * 2
-
-      if (this.$breakpoint.xs) {
-        visibleCount = this.stepsAround * 2 - 1
-      }
-      if (this.$breakpoint.s) {
-        visibleCount = this.stepsAround * 2
-      }
-      if (this.$breakpoint.m) {
-        visibleCount = visibleCount + 1
-      }
+      const visibleCount = (this.stepsAround * 2) + 1
 
       if (this.totalSteps > visibleCount) {
         if (this.currentStep >= (this.stepsAround + 1)) {

--- a/packages/Molecules/Search/SearchResults.vue
+++ b/packages/Molecules/Search/SearchResults.vue
@@ -144,7 +144,10 @@ export default {
 
     .rpl-pagination {
       // Allow space (72px) for the back-to-top button in BaseLayout.
-      width: calc(100% - #{$rpl-space * 18});
+      padding-bottom: rem(72px);
+      @include rpl_breakpoint('s') {
+        padding-bottom: 0;
+      }
 
       @include rpl_breakpoint(m) {
         width: 100%;

--- a/packages/Molecules/Search/SearchResults.vue
+++ b/packages/Molecules/Search/SearchResults.vue
@@ -144,9 +144,8 @@ export default {
 
     .rpl-pagination {
       // Allow space (72px) for the back-to-top button in BaseLayout.
-      padding-bottom: rem(72px);
       @include rpl_breakpoint('s') {
-        padding-bottom: 0;
+        width: calc(100% - #{$rpl-space * 18});
       }
 
       @include rpl_breakpoint(m) {

--- a/packages/Organisms/Markup/stories.js
+++ b/packages/Organisms/Markup/stories.js
@@ -7,7 +7,7 @@ import {
 
 import RplMarkup from './Markup.vue'
 import readme from './README.md'
-import { demoData } from '../../../src/storybook-components/_data/demoData.js'
+import { demoData } from '../../../src/storybook-components/_data/demoData'
 
 storiesOf('Organisms/Markup', module)
   .addDecorator(VueInfoAddon)

--- a/src/storybook-components/EventSearchPage.vue
+++ b/src/storybook-components/EventSearchPage.vue
@@ -15,6 +15,7 @@
 
     <rpl-page-layout
       :sidebar="sidebar"
+      :withSearch="true"
       class="main"
     >
       <template slot="aboveContent">

--- a/src/storybook-components/GrantSearchPage.vue
+++ b/src/storybook-components/GrantSearchPage.vue
@@ -15,6 +15,7 @@
 
     <rpl-page-layout
       :sidebar="sidebar"
+      :withSearch="true"
       class="main"
     >
       <template slot="aboveContent">

--- a/src/storybook-components/SearchPage.vue
+++ b/src/storybook-components/SearchPage.vue
@@ -15,6 +15,7 @@
 
     <rpl-page-layout
       :sidebar="sidebar"
+      :withSearch="true"
       class="main"
     >
       <template slot="aboveContent">

--- a/test/__snapshots__/storyshots.test.js.snap
+++ b/test/__snapshots__/storyshots.test.js.snap
@@ -17632,6 +17632,38 @@ exports[`RippleStoryshots Molecules/Layout Page Layout 1`] = `
             
           </td>
         </tr>
+        <tr
+          class="props-table-row"
+          data-v-5bd9cdea=""
+          data-v-91bb5cde=""
+        >
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+    withSearch
+    
+            <!---->
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            boolean
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -18178,6 +18210,38 @@ exports[`RippleStoryshots Molecules/Layout Page Layout with Sidebar 1`] = `
             data-v-5bd9cdea=""
           >
             string
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+        </tr>
+        <tr
+          class="props-table-row"
+          data-v-5bd9cdea=""
+          data-v-91bb5cde=""
+        >
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+    withSearch
+    
+            <!---->
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            boolean
           </td>
            
           <td
@@ -18750,6 +18814,38 @@ exports[`RippleStoryshots Molecules/Layout Page Layout with custom columns 1`] =
             data-v-5bd9cdea=""
           >
             string
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+        </tr>
+        <tr
+          class="props-table-row"
+          data-v-5bd9cdea=""
+          data-v-91bb5cde=""
+        >
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+    withSearch
+    
+            <!---->
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            boolean
           </td>
            
           <td
@@ -20575,6 +20671,52 @@ exports[`RippleStoryshots Molecules/Pagination Pagination 1`] = `
             /
           </span>
         </li>
+        <li
+          class="rpl-pagination__list-item"
+        >
+          <button
+            class="rpl-pagination__step"
+          >
+            <span
+              class="rpl-pagination__step-label"
+            >
+              Go to page
+            </span>
+            
+        4
+      
+          </button>
+           
+          <span
+            aria-hidden="true"
+            class="rpl-pagination__list-item-slash"
+          >
+            /
+          </span>
+        </li>
+        <li
+          class="rpl-pagination__list-item"
+        >
+          <button
+            class="rpl-pagination__step"
+          >
+            <span
+              class="rpl-pagination__step-label"
+            >
+              Go to page
+            </span>
+            
+        5
+      
+          </button>
+           
+          <span
+            aria-hidden="true"
+            class="rpl-pagination__list-item-slash"
+          >
+            /
+          </span>
+        </li>
       </ol>
        
       <div
@@ -21813,6 +21955,52 @@ exports[`RippleStoryshots Molecules/Search Card Search Results 1`] = `
                   /
                 </span>
               </li>
+              <li
+                class="rpl-pagination__list-item"
+              >
+                <button
+                  class="rpl-pagination__step"
+                >
+                  <span
+                    class="rpl-pagination__step-label"
+                  >
+                    Go to page
+                  </span>
+                  
+        4
+      
+                </button>
+                 
+                <span
+                  aria-hidden="true"
+                  class="rpl-pagination__list-item-slash"
+                >
+                  /
+                </span>
+              </li>
+              <li
+                class="rpl-pagination__list-item"
+              >
+                <button
+                  class="rpl-pagination__step"
+                >
+                  <span
+                    class="rpl-pagination__step-label"
+                  >
+                    Go to page
+                  </span>
+                  
+        5
+      
+                </button>
+                 
+                <span
+                  aria-hidden="true"
+                  class="rpl-pagination__list-item-slash"
+                >
+                  /
+                </span>
+              </li>
             </ol>
              
             <div
@@ -22471,6 +22659,52 @@ exports[`RippleStoryshots Molecules/Search Grant Search Results 1`] = `
                   </span>
                   
         3
+      
+                </button>
+                 
+                <span
+                  aria-hidden="true"
+                  class="rpl-pagination__list-item-slash"
+                >
+                  /
+                </span>
+              </li>
+              <li
+                class="rpl-pagination__list-item"
+              >
+                <button
+                  class="rpl-pagination__step"
+                >
+                  <span
+                    class="rpl-pagination__step-label"
+                  >
+                    Go to page
+                  </span>
+                  
+        4
+      
+                </button>
+                 
+                <span
+                  aria-hidden="true"
+                  class="rpl-pagination__list-item-slash"
+                >
+                  /
+                </span>
+              </li>
+              <li
+                class="rpl-pagination__list-item"
+              >
+                <button
+                  class="rpl-pagination__step"
+                >
+                  <span
+                    class="rpl-pagination__step-label"
+                  >
+                    Go to page
+                  </span>
+                  
+        5
       
                 </button>
                  
@@ -24483,6 +24717,52 @@ exports[`RippleStoryshots Molecules/Search Search Results 1`] = `
                   </span>
                   
         3
+      
+                </button>
+                 
+                <span
+                  aria-hidden="true"
+                  class="rpl-pagination__list-item-slash"
+                >
+                  /
+                </span>
+              </li>
+              <li
+                class="rpl-pagination__list-item"
+              >
+                <button
+                  class="rpl-pagination__step"
+                >
+                  <span
+                    class="rpl-pagination__step-label"
+                  >
+                    Go to page
+                  </span>
+                  
+        4
+      
+                </button>
+                 
+                <span
+                  aria-hidden="true"
+                  class="rpl-pagination__list-item-slash"
+                >
+                  /
+                </span>
+              </li>
+              <li
+                class="rpl-pagination__list-item"
+              >
+                <button
+                  class="rpl-pagination__step"
+                >
+                  <span
+                    class="rpl-pagination__step-label"
+                  >
+                    Go to page
+                  </span>
+                  
+        5
       
                 </button>
                  
@@ -45348,7 +45628,7 @@ exports[`RippleStoryshots Templates Event search page demo 1`] = `
   </header>
     
   <main
-    class="rpl-page main"
+    class="rpl-page main rpl-page--with-search"
   >
     <section
       class="rpl-above-content-container"
@@ -45569,6 +45849,52 @@ exports[`RippleStoryshots Templates Event search page demo 1`] = `
                             </span>
                             
         3
+      
+                          </button>
+                           
+                          <span
+                            aria-hidden="true"
+                            class="rpl-pagination__list-item-slash"
+                          >
+                            /
+                          </span>
+                        </li>
+                        <li
+                          class="rpl-pagination__list-item"
+                        >
+                          <button
+                            class="rpl-pagination__step"
+                          >
+                            <span
+                              class="rpl-pagination__step-label"
+                            >
+                              Go to page
+                            </span>
+                            
+        4
+      
+                          </button>
+                           
+                          <span
+                            aria-hidden="true"
+                            class="rpl-pagination__list-item-slash"
+                          >
+                            /
+                          </span>
+                        </li>
+                        <li
+                          class="rpl-pagination__list-item"
+                        >
+                          <button
+                            class="rpl-pagination__step"
+                          >
+                            <span
+                              class="rpl-pagination__step-label"
+                            >
+                              Go to page
+                            </span>
+                            
+        5
       
                           </button>
                            
@@ -46340,7 +46666,7 @@ exports[`RippleStoryshots Templates Grant search page demo 1`] = `
   </header>
     
   <main
-    class="rpl-page main"
+    class="rpl-page main rpl-page--with-search"
   >
     <section
       class="rpl-above-content-container"
@@ -46563,6 +46889,52 @@ exports[`RippleStoryshots Templates Grant search page demo 1`] = `
                             </span>
                             
         3
+      
+                          </button>
+                           
+                          <span
+                            aria-hidden="true"
+                            class="rpl-pagination__list-item-slash"
+                          >
+                            /
+                          </span>
+                        </li>
+                        <li
+                          class="rpl-pagination__list-item"
+                        >
+                          <button
+                            class="rpl-pagination__step"
+                          >
+                            <span
+                              class="rpl-pagination__step-label"
+                            >
+                              Go to page
+                            </span>
+                            
+        4
+      
+                          </button>
+                           
+                          <span
+                            aria-hidden="true"
+                            class="rpl-pagination__list-item-slash"
+                          >
+                            /
+                          </span>
+                        </li>
+                        <li
+                          class="rpl-pagination__list-item"
+                        >
+                          <button
+                            class="rpl-pagination__step"
+                          >
+                            <span
+                              class="rpl-pagination__step-label"
+                            >
+                              Go to page
+                            </span>
+                            
+        5
       
                           </button>
                            
@@ -62061,6 +62433,52 @@ exports[`RippleStoryshots Templates Print Page 1`] = `
                         /
                       </span>
                     </li>
+                    <li
+                      class="rpl-pagination__list-item"
+                    >
+                      <button
+                        class="rpl-pagination__step"
+                      >
+                        <span
+                          class="rpl-pagination__step-label"
+                        >
+                          Go to page
+                        </span>
+                        
+        4
+      
+                      </button>
+                       
+                      <span
+                        aria-hidden="true"
+                        class="rpl-pagination__list-item-slash"
+                      >
+                        /
+                      </span>
+                    </li>
+                    <li
+                      class="rpl-pagination__list-item"
+                    >
+                      <button
+                        class="rpl-pagination__step"
+                      >
+                        <span
+                          class="rpl-pagination__step-label"
+                        >
+                          Go to page
+                        </span>
+                        
+        5
+      
+                      </button>
+                       
+                      <span
+                        aria-hidden="true"
+                        class="rpl-pagination__list-item-slash"
+                      >
+                        /
+                      </span>
+                    </li>
                   </ol>
                    
                   <div
@@ -73070,7 +73488,7 @@ exports[`RippleStoryshots Templates Search page demo 1`] = `
   </header>
     
   <main
-    class="rpl-page main"
+    class="rpl-page main rpl-page--with-search"
   >
     <section
       class="rpl-above-content-container"
@@ -73326,6 +73744,52 @@ exports[`RippleStoryshots Templates Search page demo 1`] = `
                               </span>
                               
         3
+      
+                            </button>
+                             
+                            <span
+                              aria-hidden="true"
+                              class="rpl-pagination__list-item-slash"
+                            >
+                              /
+                            </span>
+                          </li>
+                          <li
+                            class="rpl-pagination__list-item"
+                          >
+                            <button
+                              class="rpl-pagination__step"
+                            >
+                              <span
+                                class="rpl-pagination__step-label"
+                              >
+                                Go to page
+                              </span>
+                              
+        4
+      
+                            </button>
+                             
+                            <span
+                              aria-hidden="true"
+                              class="rpl-pagination__list-item-slash"
+                            >
+                              /
+                            </span>
+                          </li>
+                          <li
+                            class="rpl-pagination__list-item"
+                          >
+                            <button
+                              class="rpl-pagination__step"
+                            >
+                              <span
+                                class="rpl-pagination__step-label"
+                              >
+                                Go to page
+                              </span>
+                              
+        5
       
                             </button>
                              


### PR DESCRIPTION
Make pagination in search result wrap full width and add padding-bottom to account for mobile. 

<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2629


### Changed

1.  Remove conditionally setting pagination steps per breakpoint (breaks in SSR - SDPA-2629)
1.  Reserve space for scroll to top to sit below pagination steps

### Screenshots

#### Before

<img width="324" alt="Screen Shot 2019-06-03 at 2 43 22 pm" src="https://user-images.githubusercontent.com/2186721/58776434-0a2e9580-860e-11e9-95f0-c54677b3e7a7.png">


#### After

<img width="331" alt="Screen Shot 2019-06-03 at 2 42 41 pm" src="https://user-images.githubusercontent.com/2186721/58776437-0ef34980-860e-11e9-91f7-20e94ef8c381.png">


<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
