### PR TITLE
Added ability to pass custom controls as props to map.

### DIFF
--- a/packages/Molecules/Map/Map.vue
+++ b/packages/Molecules/Map/Map.vue
@@ -38,11 +38,13 @@ let map,
  */
 const methods = {
   createMap () {
+    const controls = [new ol.control.Zoom()];
+    if (this.customControls) {
+      controls.push(...this.customControls);
+    }
     map = new ol.Map({
       target: 'map',
-      controls: [
-        new ol.control.Zoom()
-      ],
+      controls,
       view: new ol.View({
         center: this.center,
         zoom: this.zoom,
@@ -245,6 +247,10 @@ export default {
       default: function () {
         return {}
       }
+    },
+    customControls: {
+      type: Array,
+      default: null
     }
   },
   data: function () {

--- a/test/__snapshots__/storyshots.test.js.snap
+++ b/test/__snapshots__/storyshots.test.js.snap
@@ -20552,6 +20552,38 @@ exports[`RippleStoryshots Molecules/Map Map with no data 1`] = `
             
           </td>
         </tr>
+        <tr
+          class="props-table-row"
+          data-v-5bd9cdea=""
+          data-v-91bb5cde=""
+        >
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+    customControls
+    
+            <!---->
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            array
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+           
+          <td
+            data-v-5bd9cdea=""
+          >
+            
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->
The zoom controls are added to the map by default, but I wanted to be able to add other controls such as the FullScreen control (I've added a screenshot of this)

@tim-yao Not sure if I have permissions to add reviewers or labels - but I think this is ready
### Changed
1.  Map.vue

### Screenshots
You can see in this screenshot I've passed in the default OpenLayers FullScreen control and it has rendered the fullscreen button on the map.
![image](https://user-images.githubusercontent.com/1787606/59242654-b5170300-8c4f-11e9-9c3b-a6a344e6ec24.png)


<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
