### PR TITLE
[SDPA-2945] Prevent underline from showing after the icon on a text link.

### DIFF
--- a/packages/components/Atoms/Icon/TextIcon.vue
+++ b/packages/components/Atoms/Icon/TextIcon.vue
@@ -1,13 +1,13 @@
 <template>
   <span v-if="text && symbol && placement === 'before'">
-    <span v-if="textWordCount > 1" class="rpl-text-icon__group"><rpl-icon :symbol="symbol" :color="color" :size="size" class="rpl-text-icon--before"/>{{ textFirstWord }}</span>
+    <span v-if="textWordCount > 1" class="rpl-text-icon__group"><rpl-icon v-bind="iconProps" />{{ textFirstWord }}</span>
     <span v-if="textWordCount > 1">{{ textWithoutFirstWord }}</span>
-    <span v-if="textWordCount <= 1" class="rpl-text-icon__group"><rpl-icon :symbol="symbol" :color="color" :size="size" class="rpl-text-icon--before"/>{{ text }}</span>
+    <span v-else class="rpl-text-icon__group"><rpl-icon v-bind="iconProps" />{{ text }}</span>
   </span>
   <span v-else-if="text && symbol && placement === 'after'">
     <span v-if="textWordCount > 1">{{ textWithoutLastWord }}</span>
-    <span v-if="textWordCount > 1" class="rpl-text-icon__group">{{ textLastWord }}<rpl-icon :symbol="symbol" :color="color" :size="size" class="rpl-text-icon--after" /></span>
-    <span v-if="textWordCount <= 1" class="rpl-text-icon__group">{{ text }}<rpl-icon :symbol="symbol" :color="color" :size="size" class="rpl-text-icon--after" /></span>
+    <span v-if="textWordCount > 1" class="rpl-text-icon__group">{{ textLastWord }}<rpl-icon v-bind="iconProps" /></span>
+    <span v-else class="rpl-text-icon__group">{{ text }}<rpl-icon v-bind="iconProps" /></span>
   </span>
   <span v-else-if="text">{{ text }}</span>
 </template>
@@ -42,6 +42,14 @@ export default {
     },
     textFirstWord: function () {
       return this.text.substr(0, this.text.indexOf(' '))
+    },
+    iconProps: function () {
+      return {
+        symbol: this.symbol,
+        color: this.color,
+        size: this.size,
+        class: `rpl-text-icon--${this.placement}`
+      }
     }
   }
 }

--- a/src/test/__snapshots__/storyshots.test.js.snap
+++ b/src/test/__snapshots__/storyshots.test.js.snap
@@ -1302,8 +1302,6 @@ exports[`RippleStoryshots Atoms/Icon Text Icon 1`] = `
      Link
     <!---->
   </span>
-   
-  <!---->
 </span>
 `;
 
@@ -1440,8 +1438,6 @@ exports[`RippleStoryshots Atoms/Link Text Link 1`] = `
            Link
           <!---->
         </span>
-         
-        <!---->
       </span>
     </span>
   </span>
@@ -1508,8 +1504,6 @@ exports[`RippleStoryshots Molecules/Alert Alert 1`] = `
                more
               <!---->
             </span>
-             
-            <!---->
           </span>
         </span>
       </span>
@@ -2088,8 +2082,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        details
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2188,8 +2180,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        calendar
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2272,8 +2262,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        more
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2357,8 +2345,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        details
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2442,8 +2428,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        details
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2542,8 +2526,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        calendar
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2626,8 +2608,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        more
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2726,8 +2706,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        calendar
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2826,8 +2804,6 @@ exports[`RippleStoryshots Molecules/Card/Card Carousel Default 1`] = `
                        calendar
                       <!---->
                     </span>
-                     
-                    <!---->
                   </span>
                 </div>
               </a>
@@ -2905,8 +2881,6 @@ exports[`RippleStoryshots Molecules/Card/Card Content (base) Default 1`] = `
          more
         <!---->
       </span>
-       
-      <!---->
     </span>
   </div>
 </a>
@@ -3078,8 +3052,6 @@ exports[`RippleStoryshots Molecules/Card/Card Event Default 1`] = `
          details
         <!---->
       </span>
-       
-      <!---->
     </span>
   </div>
 </a>
@@ -3159,8 +3131,6 @@ exports[`RippleStoryshots Molecules/Card/Card Honour Roll Default 1`] = `
          profile
         <!---->
       </span>
-       
-      <!---->
     </span>
   </div>
 </a>
@@ -3231,8 +3201,6 @@ exports[`RippleStoryshots Molecules/Card/Card Image Navigation Default 1`] = `
            action
           <!---->
         </span>
-         
-        <!---->
       </span>
     </div>
   </div>
@@ -3326,8 +3294,6 @@ exports[`RippleStoryshots Molecules/Card/Card Keydates Default 1`] = `
          more
         <!---->
       </span>
-       
-      <!---->
     </span>
   </div>
 </a>
@@ -3373,8 +3339,6 @@ exports[`RippleStoryshots Molecules/Card/Card Navigation Default 1`] = `
          more
         <!---->
       </span>
-       
-      <!---->
     </span>
   </div>
 </a>
@@ -3503,8 +3467,6 @@ exports[`RippleStoryshots Molecules/Card/Card Promotion Default 1`] = `
          more
         <!---->
       </span>
-       
-      <!---->
     </span>
   </div>
 </a>
@@ -4528,8 +4490,6 @@ exports[`RippleStoryshots Molecules/Form Default 1`] = `
                         <span>
                           <!---->
                            
-                          <!---->
-                           
                           <span
                             class="rpl-text-icon__group"
                           >
@@ -5182,8 +5142,6 @@ exports[`RippleStoryshots Molecules/Form Default 1`] = `
                 <span>
                    search filters
                 </span>
-                 
-                <!---->
               </span>
             </button>
              
@@ -6353,8 +6311,6 @@ exports[`RippleStoryshots Molecules/RelatedLinks Default 1`] = `
                    content
                   <!---->
                 </span>
-                 
-                <!---->
               </span>
             </span>
           </span>
@@ -8371,8 +8327,6 @@ exports[`RippleStoryshots Molecules/WhatsNext Default 1`] = `
                    content
                   <!---->
                 </span>
-                 
-                <!---->
               </span>
             </span>
           </span>
@@ -8958,8 +8912,6 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
                details
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </a>
@@ -9036,8 +8988,6 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
                details
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </a>
@@ -9114,8 +9064,6 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
                details
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </a>
@@ -9192,8 +9140,6 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
                details
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </a>
@@ -9270,8 +9216,6 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
                details
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </a>
@@ -9565,8 +9509,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Default 1`] = `
                      link
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9597,8 +9539,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Default 1`] = `
                      link
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9629,8 +9569,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Default 1`] = `
                      here
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9661,8 +9599,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Default 1`] = `
                      link
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9694,8 +9630,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Default 1`] = `
                      more
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9765,8 +9699,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Intro Banner 1`] = `
                      visit
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9787,8 +9719,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Intro Banner 1`] = `
                 class="rpl-text-label rpl-text-label--small rpl-text-label--small--underline"
               >
                 <span>
-                  <!---->
-                   
                   <!---->
                    
                   <span
@@ -9827,8 +9757,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Intro Banner 1`] = `
                      Programs
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9859,8 +9787,6 @@ exports[`RippleStoryshots Organisms/HeroBanner Intro Banner 1`] = `
                      Bookings
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -9946,8 +9872,6 @@ exports[`RippleStoryshots Organisms/HeroBanner with CTA 1`] = `
                      prepare
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -10607,8 +10531,6 @@ exports[`RippleStoryshots Organisms/Markup Markup/Link 1`] = `
                  link
                 <!---->
               </span>
-               
-              <!---->
             </span>
           </span>
         </span>
@@ -10941,8 +10863,6 @@ exports[`RippleStoryshots Organisms/News Featured News 1`] = `
                action
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </div>
@@ -11017,8 +10937,6 @@ exports[`RippleStoryshots Organisms/News Featured News 1`] = `
                action
               <!---->
             </span>
-             
-            <!---->
           </span>
         </div>
       </div>
@@ -11083,8 +11001,6 @@ exports[`RippleStoryshots Organisms/News News Listing 1`] = `
                      Conference
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -11133,8 +11049,6 @@ exports[`RippleStoryshots Organisms/News News Listing 1`] = `
                      Out
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -11183,8 +11097,6 @@ exports[`RippleStoryshots Organisms/News News Listing 1`] = `
                      Triennial
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -11233,8 +11145,6 @@ exports[`RippleStoryshots Organisms/News News Listing 1`] = `
                      Fund
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -11283,8 +11193,6 @@ exports[`RippleStoryshots Organisms/News News Listing 1`] = `
                      Review
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -11333,8 +11241,6 @@ exports[`RippleStoryshots Organisms/News News Listing 1`] = `
                      Violence
                     <!---->
                   </span>
-                   
-                  <!---->
                 </span>
               </span>
             </span>
@@ -11631,8 +11537,6 @@ exports[`RippleStoryshots Organisms/Publication Publication Image 1`] = `
         <span>
            Figure 1.2 in full screen
         </span>
-         
-        <!---->
       </span>
     </button>
      
@@ -11650,8 +11554,6 @@ exports[`RippleStoryshots Organisms/Publication Publication Image 1`] = `
         <span>
            Figure 1.2 in table format
         </span>
-         
-        <!---->
       </span>
     </button>
      
@@ -11673,8 +11575,6 @@ exports[`RippleStoryshots Organisms/Publication Publication Image 1`] = `
         <span>
            Figure 1.2
         </span>
-         
-        <!---->
       </span>
     </a>
   </div>


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2945

### Changed

* Use 'else' statement to avoid vue printing a <!-- --> comment (and inserting an underlined space).
* Move rpl-icon property definitions into a computed value to increase code readability.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
Before:
<img width="501" alt="Screen Shot 2019-07-24 at 3 11 06 pm" src="https://user-images.githubusercontent.com/12739575/61767264-158c8900-ae27-11e9-884d-e056227c36de.png">

After:
<img width="513" alt="Screen Shot 2019-07-24 at 3 11 15 pm" src="https://user-images.githubusercontent.com/12739575/61767263-158c8900-ae27-11e9-99dd-3bfc909f9259.png">