### PR TITLE
[SDPA-1166] Form alerts.

### DIFF
--- a/packages/components/Molecules/Form/formAlert.vue
+++ b/packages/components/Molecules/Form/formAlert.vue
@@ -26,21 +26,25 @@ export default {
       return this.getValues().color
     },
     classes () {
-      return [ 'rpl-form-alert--' + this.variant ]
+      const suffix = this.getValues().classSuffix
+      return suffix ? 'rpl-form-alert--' + this.getValues().classSuffix : null
     }
   },
   methods: {
     getValues () {
-      let icon, color
+      let icon, color, classSuffix
       switch (this.variant) {
         case 'success':
           icon = 'success'
           color = 'success'
+          classSuffix = 'success'
           break
 
+        case 'error':
         case 'danger':
           icon = 'alert_information'
           color = 'danger'
+          classSuffix = 'danger'
           break
 
         default:
@@ -49,7 +53,8 @@ export default {
       }
       return {
         icon,
-        color
+        color,
+        classSuffix
       }
     }
   }

--- a/packages/components/Molecules/Form/index.vue
+++ b/packages/components/Molecules/Form/index.vue
@@ -1,7 +1,8 @@
 <template>
   <form class="rpl-form" @submit="onSubmit">
     <h3 class="rpl-form__title" v-if="title">{{title}}</h3>
-    <rpl-form-alert v-if="formData.formState.response && formData.formState.response.message" :variant="formData.formState.response.status" v-html="formData.formState.response.message">
+    <rpl-form-alert v-if="formData.formState.response && formData.formState.response.message" :variant="formData.formState.response.status">
+      <span v-html="formData.formState.response.message"></span>
     </rpl-form-alert>
     <vue-form-generator
       :schema="formData.schema"

--- a/packages/components/Molecules/Form/stories.js
+++ b/packages/components/Molecules/Form/stories.js
@@ -314,7 +314,7 @@ storiesOf('Molecules/Form', module)
         formData: {
           model: {
             submissionType: 'Success',
-            otherMessage: 'Thank you! Your response has been submitted.'
+            message: 'Thank you! Your response has been submitted.'
           },
           schema: {
             fields: [
@@ -331,8 +331,8 @@ storiesOf('Molecules/Form', module)
               {
                 type: 'input',
                 inputType: 'text',
-                label: 'Other message',
-                model: 'otherMessage'
+                label: 'Message',
+                model: 'message'
               },
               {
                 type: 'rplsubmitloader',
@@ -351,7 +351,7 @@ storiesOf('Molecules/Form', module)
         return new Promise((resolve, reject) => {
           setTimeout(() => {
             const status = this.formData.model.submissionType.toLowerCase()
-            const message = this.formData.model.otherMessage
+            const message = this.formData.model.message
             this.formData.formState = {
               response: { status, message }
             }

--- a/packages/components/Molecules/Form/stories.js
+++ b/packages/components/Molecules/Form/stories.js
@@ -300,3 +300,64 @@ storiesOf('Molecules/Form', module)
       }
     }
   }))
+  .add('Submission Alerts', () => ({
+    components: { RplForm },
+    template: `<rpl-form :formData="formData" :submitHandler="submitHandler" :title="title"></rpl-form>`,
+    data () {
+      return {
+        title: 'Submission Alerts',
+        isNewModel: true,
+        options: {
+          validateAfterChanged: true,
+          validateAfterLoad: false
+        },
+        formData: {
+          model: {
+            submissionType: 'Success',
+            otherMessage: 'Thank you! Your response has been submitted.'
+          },
+          schema: {
+            fields: [
+              {
+                type: 'radios',
+                label: 'Alert type',
+                model: 'submissionType',
+                values: [
+                  'Success',
+                  'Error',
+                  'Other'
+                ]
+              },
+              {
+                type: 'input',
+                inputType: 'text',
+                label: 'Other message',
+                model: 'otherMessage'
+              },
+              {
+                type: 'rplsubmitloader',
+                buttonText: 'Submit',
+                loading: false,
+                autoUpdate: true
+              }
+            ]
+          },
+          formState: {}
+        }
+      }
+    },
+    methods: {
+      submitHandler () {
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            const status = this.formData.model.submissionType.toLowerCase()
+            const message = this.formData.model.otherMessage
+            this.formData.formState = {
+              response: { status, message }
+            }
+            resolve()
+          }, 250)
+        })
+      }
+    }
+  }))

--- a/src/test/__snapshots__/storyshots.test.js.snap
+++ b/src/test/__snapshots__/storyshots.test.js.snap
@@ -5281,10 +5281,10 @@ exports[`RippleStoryshots Molecules/Form Submission Alerts 1`] = `
         class="form-group field-input"
       >
         <label
-          for="other-message"
+          for="message"
         >
           <span>
-            Other message
+            Message
           </span>
            
           <!---->
@@ -5298,7 +5298,7 @@ exports[`RippleStoryshots Molecules/Form Submission Alerts 1`] = `
           >
             <input
               class="form-control"
-              id="other-message"
+              id="message"
               type="text"
             />
             <!---->

--- a/src/test/__snapshots__/storyshots.test.js.snap
+++ b/src/test/__snapshots__/storyshots.test.js.snap
@@ -5200,6 +5200,150 @@ exports[`RippleStoryshots Molecules/Form Default 1`] = `
 </form>
 `;
 
+exports[`RippleStoryshots Molecules/Form Submission Alerts 1`] = `
+<form
+  class="rpl-form"
+>
+  <h3
+    class="rpl-form__title"
+  >
+    Submission Alerts
+  </h3>
+   
+  <!---->
+   
+  <div
+    class="vue-form-generator"
+  >
+    <fieldset>
+      <div
+        class="form-group field-radios"
+      >
+        <label
+          for="alert-type"
+        >
+          <span>
+            Alert type
+          </span>
+           
+          <!---->
+        </label>
+         
+        <div
+          class="field-wrap"
+        >
+          <div
+            class="radio-list"
+          >
+            <label
+              class="is-checked"
+            >
+              <input
+                id="alert-type-12"
+                name="submissionType"
+                type="radio"
+                value="Success"
+              />
+              Success
+            </label>
+            <label
+              class=""
+            >
+              <input
+                id="alert-type-13"
+                name="submissionType"
+                type="radio"
+                value="Error"
+              />
+              Error
+            </label>
+            <label
+              class=""
+            >
+              <input
+                id="alert-type-14"
+                name="submissionType"
+                type="radio"
+                value="Other"
+              />
+              Other
+            </label>
+          </div>
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+      <div
+        class="form-group field-input"
+      >
+        <label
+          for="other-message"
+        >
+          <span>
+            Other message
+          </span>
+           
+          <!---->
+        </label>
+         
+        <div
+          class="field-wrap"
+        >
+          <div
+            class="wrapper"
+          >
+            <input
+              class="form-control"
+              id="other-message"
+              type="text"
+            />
+            <!---->
+          </div>
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+      <div
+        class="form-group field-rplsubmitloader"
+      >
+        <!---->
+         
+        <div
+          class="field-wrap"
+        >
+          <button
+            class="rpl-submit-loader form-control"
+            type="submit"
+          >
+            <span
+              class="rpl-submit-loader__text"
+            >
+              Submit
+            </span>
+             
+            <!---->
+          </button>
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+    </fieldset>
+  </div>
+</form>
+`;
+
 exports[`RippleStoryshots Molecules/Layout Base Layout 1`] = `
 <div
   class="rpl-site-layout"


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-1166

### Changed

* Form alert content was being overridden by a v-html="" property. Message inserted within form-alert slot.
* 'Error' color is now 'Danger' - Add support for both 'danger' and 'error' variant for backwards compatibility.
* Added a storybook page to test alerts.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
<img width="974" alt="Screen Shot 2019-07-24 at 5 57 44 pm" src="https://user-images.githubusercontent.com/12739575/61775630-a457d080-ae3c-11e9-8335-5c3bfef5a470.png">
<img width="1110" alt="Screen Shot 2019-07-24 at 5 57 16 pm" src="https://user-images.githubusercontent.com/12739575/61775631-a4f06700-ae3c-11e9-97f5-c47266ab5963.png">
<img width="589" alt="Screen Shot 2019-07-24 at 5 55 22 pm" src="https://user-images.githubusercontent.com/12739575/61775632-a4f06700-ae3c-11e9-8cd0-dbb58e4ae457.png">
<img width="587" alt="Screen Shot 2019-07-24 at 5 54 57 pm" src="https://user-images.githubusercontent.com/12739575/61775633-a4f06700-ae3c-11e9-8cf1-68d711062509.png">
<img width="588" alt="Screen Shot 2019-07-24 at 5 54 27 pm" src="https://user-images.githubusercontent.com/12739575/61775634-a588fd80-ae3c-11e9-85de-5a7c901ed889.png">
