### PR TITLE
AIODPC-8: Start nuxt without yarn

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -33,4 +33,4 @@ RUN  . /home/.bashrc \
 ENV HOST 0.0.0.0
 EXPOSE 3000
 
-CMD ["yarn", "run", "start"]
+CMD ["./node_modules/.bin/nuxt", "start"]


### PR DESCRIPTION
This will allow nuxt to gracefully handle a shutdown of the container.

