### PR TITLE
[SDPA-3203] Added pagination correct number highlighting fix.

### DIFF
--- a/packages/components/Molecules/Pagination/index.vue
+++ b/packages/components/Molecules/Pagination/index.vue
@@ -95,9 +95,6 @@ export default {
   watch: {
     initialStep (newVal, oldVal) {
       this.currentStep = newVal
-    },
-    totalSteps (newVal, oldVal) {
-      this.currentStep = 1
     }
   }
 }

--- a/packages/ripple-nuxt-tide/modules/search/lib/searchmixin.js
+++ b/packages/ripple-nuxt-tide/modules/search/lib/searchmixin.js
@@ -165,7 +165,7 @@ const searchMixin = {
       if (this.searchForm.textSearch === undefined) {
         this.searchForm.prefillSearchTerm = this.$route.query.q
       }
-      this.pager.initialStep = Number(this.$route.query.page)
+      this.pager.initialStep = this.$route.query.page ? Number(this.$route.query.page) : 1
     }
   }
 }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-3203

### Changed

1.  searchmixin 'this.pager.initialStep' value assign correction on the watch.
2. On pagination index.vue, watch for totalsteps is removed because it was changing the value of currentsteps. This will fix the issue when you are at a certain page number on a search page and refreshing the page will still be highlighting at the correct page.

### Screenshots
![Screen Shot 2019-10-09 at 9 42 25 am](https://user-images.githubusercontent.com/20810541/66438693-35703800-ea79-11e9-96ea-e8e1d8ac247a.png)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
