### PR TITLE
[SDPA-3390] Alerts with no link FE crash fix.

### DIFF
--- a/packages/ripple-nuxt-tide/modules/alert/plugin.js
+++ b/packages/ripple-nuxt-tide/modules/alert/plugin.js
@@ -53,8 +53,8 @@ export default function ({ app, store }) {
                   title: get(alert, 'title', ''),
                   type: get(alert, 'field_alert_type.name', ''),
                   link: {
-                    text: link.title,
-                    url: link.url || link.uri
+                    text: get(link, 'title', ''),
+                    url: get(link, 'url', '') || get(link, 'uri', '')
                   },
                   sites
                 }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-3390

### Changed

1.  Change in plugin.js to check for null link title and link URL. At BE we made the link field for an alert not mandatory. So there will be situations when these fields can be null.

### Screenshots
<img width="1440" alt="Screen Shot 2019-10-28 at 9 10 58 pm" src="https://user-images.githubusercontent.com/20810541/67670448-0a1da080-f9c8-11e9-9996-2f85529a4881.png">

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
