### PR TITLE
[SDPA-3533] News info goes offscreen bug fix.

### DIFF
--- a/packages/components/Molecules/List/index.vue
+++ b/packages/components/Molecules/List/index.vue
@@ -116,6 +116,7 @@ export default {
       @include rpl_text_color($rpl-list-link-color);
       display: table-cell;
       padding: $rpl-list-text-padding;
+      word-break: break-word;
 
       #{$root}--normal & {
         @include rpl_typography_ruleset($rpl-list-text-normal-ruleset);


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-3533

### Changed

1.  Added break-word for rpl-list__text to break longer word to fit in smaller screens.

### Screenshots
![Screen Shot 2019-12-03 at 2 56 22 pm](https://user-images.githubusercontent.com/20810541/70019394-333fdb00-15dd-11ea-8ab2-5150ebdbb262.png)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
