### PR TITLE
MYVIC-69 Added attributions to map.

### DIFF
--- a/packages/components/Molecules/Map/Map.vue
+++ b/packages/components/Molecules/Map/Map.vue
@@ -64,7 +64,7 @@ const methods = {
     baseSource = new ol.source.XYZ({
       url: this.baseMapUrl,
       transition: 1000,
-      attributions: ['© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>']
+      attributions: ['© Mapbox © OpenStreetMap']
     })
     baseLayer = new ol.layer.Tile({
       source: baseSource

--- a/packages/components/Molecules/Map/Map.vue
+++ b/packages/components/Molecules/Map/Map.vue
@@ -64,7 +64,7 @@ const methods = {
     baseSource = new ol.source.XYZ({
       url: this.baseMapUrl,
       transition: 1000,
-      attributions: ['© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>']
+      attributions: ['© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>']
     })
     baseLayer = new ol.layer.Tile({
       source: baseSource

--- a/packages/components/Molecules/Map/Map.vue
+++ b/packages/components/Molecules/Map/Map.vue
@@ -41,7 +41,10 @@ const methods = {
     map = new ol.Map({
       target: 'map',
       controls: [
-        new ol.control.Zoom()
+        new ol.control.Zoom(),
+        new ol.control.Attribution({
+          collapsible: false
+        })
       ],
       view: new ol.View({
         center: this.center,
@@ -60,7 +63,8 @@ const methods = {
   createBaseLayer () {
     baseSource = new ol.source.XYZ({
       url: this.baseMapUrl,
-      transition: 1000
+      transition: 1000,
+      attributions: ['© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>']
     })
     baseLayer = new ol.layer.Tile({
       source: baseSource

--- a/packages/components/Molecules/Map/lib/ol.js
+++ b/packages/components/Molecules/Map/lib/ol.js
@@ -17,6 +17,7 @@ import View from 'ol/View'
 import Feature from 'ol/Feature'
 import Overlay from 'ol/Overlay'
 import Zoom from 'ol/control/Zoom'
+import Attribution from 'ol/control/Attribution'
 import Icon from 'ol/style/Icon'
 import GeoJSON from 'ol/format/GeoJSON'
 import { bbox } from 'ol/loadingstrategy'
@@ -49,7 +50,8 @@ const ol = {
   View: View,
   Overlay: Overlay,
   control: {
-    Zoom
+    Zoom,
+    Attribution
   },
   layer: {
     Tile: TileLayer,


### PR DESCRIPTION
As mentioned by @kurtfoster in MYVIC-69, attributions are required on the map control:

https://docs.mapbox.com/help/how-mapbox-works/attribution/#other-mapping-frameworks

**JIRA issue:** https://digital-engagement.atlassian.net/browse/MYVIC-69

### Changed

1. Added attribution control to map
1. Added mapbox/osm attribution to the open street map tile layer

### Screenshots

![image](https://user-images.githubusercontent.com/353138/74691901-dac1c680-5238-11ea-8ea7-037e756a51df.png)
