### PR TITLE
E2E - Update social links to use button class.

### DIFF
--- a/packages/ripple-test-tools/step_definitions/components/index.js
+++ b/packages/ripple-test-tools/step_definitions/components/index.js
@@ -815,7 +815,7 @@ Then(`the share this component should have the title "Share this"`, () => {
 Then(`the share this component should have the following social links:`, (dataTable) => {
   const networks = dataTable.rawTable.slice(1)
   networks.forEach((network, index) => {
-    cy.get('.rpl-share-this__social').eq(index).then(shareLink => {
+    cy.get('.rpl-share-this__button').eq(index).then(shareLink => {
       const title = network[0]
       expect(shareLink).to.contain.text(title)
       cy.wrap(shareLink).get('.rpl-icon').should('exist')


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** No ticket.

### Changed

1.  Changed `.rpl-share-this__social` to `.rpl-share-this__button` as social class no longer exists.

NOTE: I realize this may cause incompatibilities with sites less than 1.8.0. Is that an issue?

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
