### PR TITLE
Accessibility: Social buttons to include '__social' class.

### DIFF
--- a/packages/components/Molecules/ShareThis/index.vue
+++ b/packages/components/Molecules/ShareThis/index.vue
@@ -4,19 +4,19 @@
     <social-sharing :url="url" inline-template networkTag="button">
       <ul class="rpl-share-this__list" :aria-label="label || 'Social networks'">
         <li v-if="$parent.en.twitter">
-          <network network="twitter" class="rpl-share-this__button">
+          <network network="twitter" class="rpl-share-this__social rpl-share-this__button">
             <span class="rpl-share-this__icon"><rpl-icon symbol="twitter" color="primary" /></span>Twitter
             <span class="rpl-share-this__hint">, opens a new window</span>
           </network>
         </li>
         <li v-if="$parent.en.facebook">
-          <network network="facebook" class="rpl-share-this__button">
+          <network network="facebook" class="rpl-share-this__social rpl-share-this__button">
             <span class="rpl-share-this__icon"><rpl-icon symbol="facebook" color="primary" /></span>Facebook
             <span class="rpl-share-this__hint">, opens a new window</span>
           </network>
         </li>
         <li v-if="$parent.en.linkedin">
-          <network network="linkedin" class="rpl-share-this__button">
+          <network network="linkedin" class="rpl-share-this__social rpl-share-this__button">
             <span class="rpl-share-this__icon"><rpl-icon symbol="linkedin" color="primary" /></span>LinkedIn
             <span class="rpl-share-this__hint">, opens a new window</span>
           </network>

--- a/src/test/__snapshots__/storyshots.test.js.snap
+++ b/src/test/__snapshots__/storyshots.test.js.snap
@@ -15753,7 +15753,7 @@ exports[`RippleStoryshots Molecules/ShareThis Share this 1`] = `
   >
     <li>
       <button
-        class="rpl-share-this__button"
+        class="rpl-share-this__social rpl-share-this__button"
         data-link="#share-twitter"
         tabindex="0"
       >
@@ -15774,7 +15774,7 @@ exports[`RippleStoryshots Molecules/ShareThis Share this 1`] = `
      
     <li>
       <button
-        class="rpl-share-this__button"
+        class="rpl-share-this__social rpl-share-this__button"
         data-link="#share-facebook"
         tabindex="0"
       >
@@ -15795,7 +15795,7 @@ exports[`RippleStoryshots Molecules/ShareThis Share this 1`] = `
      
     <li>
       <button
-        class="rpl-share-this__button"
+        class="rpl-share-this__social rpl-share-this__button"
         data-link="#share-linkedin"
         tabindex="0"
       >


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** No ticket.

### Changed

Part of the accessibility fix was setting network tag to be a button, removing the need for an inner button element. Because of this __social and __button became the same thing. __social was removed, however to avoid breaking any sites that depend on the __social class this fix will add the class name alongside __button.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
