### PR TITLE
[SDPSUP-1668] Increased timeout to 10 seconds.

### DIFF
--- a/packages/ripple-nuxt-tide/lib/core/tide.js
+++ b/packages/ripple-nuxt-tide/lib/core/tide.js
@@ -41,7 +41,7 @@ export const tide = (axios, site, config) => ({
   // Build the axios config for Tide GET request
   _axiosConfig: function (headersConfig) {
     // axios config
-    let axiosTimeout = 4000
+    let axiosTimeout = 10000
 
     // Give more time in Circle CI test
     if (process.env.NODE_ENV === 'test' || process.env.TEST) {

--- a/packages/ripple-nuxt-tide/lib/module.js
+++ b/packages/ripple-nuxt-tide/lib/module.js
@@ -14,7 +14,7 @@ const nuxtTide = function (moduleOptions) {
       target: options.baseUrl,
       // Set the proxy timeout for requesting to Tide API as 9 seconds.
       // POST request to Tide normally need more than 5 seconds to get response.
-      proxyTimeout: 9000,
+      proxyTimeout: 10000,
       onProxyRes (proxyRes, req, res) {
         // Set headers as devOps required
         proxyRes.headers[RPL_HEADER.APP_TYPE] = 'tide'


### PR DESCRIPTION
**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPSUP-1668

### Changed

1. Increased the timeout from 4 seconds to 10 seconds. This is to accommodate the semi-regular slow responses from downstream APIs.

### Screenshots

See JIRA issue comments for chart showing instances of requests taking >4s. 

