### PR TITLE
[SDPA-4106] quick exit issue with image gallery and ie browser

### DIFF
--- a/packages/components/Molecules/Layout/PageLayout.vue
+++ b/packages/components/Molecules/Layout/PageLayout.vue
@@ -8,7 +8,7 @@
         <div class="rpl-above-content__inner" :style="backgroundImage">
           <div class="rpl-above-content__top">
             <slot name="breadcrumbs"></slot>
-            <rpl-quick-exit v-if="quickexit && !menuopen" menuOffsetSelector=".rpl-above-content__inner" />
+            <rpl-quick-exit v-if="quickexit && !menuopen && !imagegallerymodalopen" menuOffsetSelector=".rpl-above-content__inner" />
           </div>
           <slot name="aboveContent"></slot>
         </div>
@@ -48,6 +48,7 @@
 import RplQuickExit from './QuickExit'
 import { RplContainer, RplRow, RplCol } from '@dpc-sdp/ripple-grid'
 import { RplSiteHeaderEventBus } from '@dpc-sdp/ripple-site-header'
+import { RplImageGalleryBus } from '@dpc-sdp/ripple-image-gallery'
 
 export default {
   components: { RplContainer, RplRow, RplCol, RplQuickExit },
@@ -74,7 +75,8 @@ export default {
   data () {
     return {
       quickexit: false,
-      menuopen: false
+      menuopen: false,
+      imagegallerymodalopen: false
     }
   },
   computed: {
@@ -97,6 +99,7 @@ export default {
   },
   mounted () {
     RplSiteHeaderEventBus.$on('open', this.setMenuOpen)
+    RplImageGalleryBus.$on('showModal', this.setImageGalleryModalOpen)
   },
   created () {
     this.quickexit = (this.quickExit !== null) ? this.quickExit : this.rplOptions.quickexit
@@ -104,6 +107,9 @@ export default {
   methods: {
     setMenuOpen (val) {
       this.menuopen = val
+    },
+    setImageGalleryModalOpen (data) {
+      this.imagegallerymodalopen = data
     }
   }
 }

--- a/packages/components/Molecules/Layout/PageLayout.vue
+++ b/packages/components/Molecules/Layout/PageLayout.vue
@@ -48,7 +48,7 @@
 import RplQuickExit from './QuickExit'
 import { RplContainer, RplRow, RplCol } from '@dpc-sdp/ripple-grid'
 import { RplSiteHeaderEventBus } from '@dpc-sdp/ripple-site-header'
-import { RplImageGalleryBus } from '@dpc-sdp/ripple-image-gallery'
+import { RplImageGalleryEventBus } from '@dpc-sdp/ripple-image-gallery'
 
 export default {
   components: { RplContainer, RplRow, RplCol, RplQuickExit },
@@ -99,7 +99,7 @@ export default {
   },
   mounted () {
     RplSiteHeaderEventBus.$on('open', this.setMenuOpen)
-    RplImageGalleryBus.$on('showModal', this.setImageGalleryModalOpen)
+    RplImageGalleryEventBus.$on('showModal', this.setImageGalleryModalOpen)
   },
   created () {
     this.quickexit = (this.quickExit !== null) ? this.quickExit : this.rplOptions.quickexit

--- a/packages/components/Organisms/ImageGallery/ImageGallery.vue
+++ b/packages/components/Organisms/ImageGallery/ImageGallery.vue
@@ -123,7 +123,7 @@ export default {
     },
     modalToggle () {
       var showModalState = this.showModal
-      this.showModal = showModalState ? false : true
+      this.showModal = !showModalState
       RplImageGalleryBus.$emit('showModal', this.showModal)
     }
   }

--- a/packages/components/Organisms/ImageGallery/ImageGallery.vue
+++ b/packages/components/Organisms/ImageGallery/ImageGallery.vue
@@ -67,7 +67,7 @@ import RplIcon from '@dpc-sdp/ripple-icon'
 import RplFittedImg from './FittedImg.vue'
 import RplImageGalleryModal from './ImageGalleryModal.vue'
 import RplFullscreenImage from './FullscreenImage.vue'
-import { RplImageGalleryBus } from './index'
+import { RplImageGalleryEventBus } from './index'
 
 export default {
   name: 'RplImageGallery',
@@ -124,7 +124,7 @@ export default {
     modalToggle () {
       var showModalState = this.showModal
       this.showModal = !showModalState
-      RplImageGalleryBus.$emit('showModal', this.showModal)
+      RplImageGalleryEventBus.$emit('showModal', this.showModal)
     }
   }
 }

--- a/packages/components/Organisms/ImageGallery/ImageGallery.vue
+++ b/packages/components/Organisms/ImageGallery/ImageGallery.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="rpl-image-gallery">
-    <button class="rpl-image-gallery__enlarge" @click="openModal()" :aria-label="enlargeText">
+    <button class="rpl-image-gallery__enlarge" @click="modalToggle()" :aria-label="enlargeText">
       <rpl-icon symbol="enlarge_screen" color="primary" />
     </button>
     <carousel
@@ -29,7 +29,7 @@
       </button>
     </div>
     <!-- Modal -->
-    <rpl-image-gallery-modal v-if="showModal" @close="showModal = false">
+    <rpl-image-gallery-modal v-if="showModal" @close="modalToggle()">
       <template slot="body">
         <carousel
           :perPage="1"
@@ -67,6 +67,7 @@ import RplIcon from '@dpc-sdp/ripple-icon'
 import RplFittedImg from './FittedImg.vue'
 import RplImageGalleryModal from './ImageGalleryModal.vue'
 import RplFullscreenImage from './FullscreenImage.vue'
+import { RplImageGalleryBus } from './index'
 
 export default {
   name: 'RplImageGallery',
@@ -111,9 +112,6 @@ export default {
     this.showCarousel = true
   },
   methods: {
-    openModal () {
-      this.showModal = true
-    },
     nextSlide () {
       this.navTo = ((this.navTo < this.totalSlides) ? (this.navTo + 1) : 0)
     },
@@ -122,6 +120,11 @@ export default {
     },
     onPageChange (slideNumber) {
       this.navTo = slideNumber
+    },
+    modalToggle () {
+      var showModalState = this.showModal
+      this.showModal = showModalState ? false : true
+      RplImageGalleryBus.$emit('showModal', this.showModal)
     }
   }
 }

--- a/packages/components/Organisms/ImageGallery/ImageGalleryModal.vue
+++ b/packages/components/Organisms/ImageGallery/ImageGalleryModal.vue
@@ -4,6 +4,7 @@
       <button class="rpl-image-gallery__modal-close" @click="closeModal()">
         <rpl-icon symbol="close" color="white" :size="iconSize" /><span>Close</span>
       </button>
+      <rpl-quick-exit class="rpl-image-gallery__modal__quickexit"  v-if="rplOptions.quickexit" />
       <div class="rpl-image-gallery__modal-body">
         <slot name="body"></slot>
       </div>
@@ -15,12 +16,14 @@
 import { isClient } from '@dpc-sdp/ripple-global/utils/helpers.js'
 import breakpoint from '@dpc-sdp/ripple-global/mixins/breakpoint'
 import { RplIcon } from '@dpc-sdp/ripple-icon'
+import RplQuickExit from '@dpc-sdp/ripple-layout/QuickExit.vue'
 
 export default {
   name: 'RplImageGalleryModal',
   mixins: [breakpoint],
   components: {
-    RplIcon
+    RplIcon,
+    RplQuickExit
   },
   methods: {
     closeModal () {
@@ -58,6 +61,11 @@ export default {
   @import "~@dpc-sdp/ripple-global/scss/tools";
   @import "./scss/image_gallery";
 
+  $rpl-image-gallery-modal-quickexit-margin-top-xs: ($rpl-space-4 * 4);
+  $rpl-image-gallery-modal-quickexit-right-position-xs: $rpl-space-2;
+  $rpl-image-gallery-modal-quickexit-margin-top-l: ($rpl-space-4 * 7);
+  $rpl-image-gallery-modal-quickexit-right-position-l: ($rpl-space * 7);
+
   .rpl-image-gallery {
     &__modal-mask {
       position: fixed;
@@ -81,6 +89,7 @@ export default {
         margin-left: ($rpl-space * 15);
         margin-right: ($rpl-space * 15);
       }
+
     }
 
     &__modal-close {
@@ -105,6 +114,20 @@ export default {
 
       span {
         @include rpl_visually_hidden;
+      }
+    }
+
+    & &__modal__quickexit {
+      position: absolute;
+
+      @include rpl_breakpoint('xs') {
+        margin-top: $rpl-image-gallery-modal-quickexit-margin-top-xs;
+        right: $rpl-image-gallery-modal-quickexit-right-position-xs;
+      }
+
+      @include rpl_breakpoint('l') {
+        margin-top: $rpl-image-gallery-modal-quickexit-margin-top-l;
+        right: $rpl-image-gallery-modal-quickexit-right-position-l;
       }
     }
   }

--- a/packages/components/Organisms/ImageGallery/index.js
+++ b/packages/components/Organisms/ImageGallery/index.js
@@ -7,9 +7,9 @@ import RplImageGalleryModal from './ImageGalleryModal.vue'
 import RplFullscreenImage from './FullscreenImage.vue'
 import RplImageGallery from './ImageGallery.vue'
 import RplComplexImage from './ComplexImage.vue'
-const RplImageGalleryBus = new Vue()
+const RplImageGalleryEventBus = new Vue()
 
-export { RplImageGalleryBus }
+export { RplImageGalleryEventBus }
 export { RplImageGalleryModal }
 export { RplFullscreenImage }
 export { RplImageGallery }

--- a/packages/components/Organisms/ImageGallery/index.js
+++ b/packages/components/Organisms/ImageGallery/index.js
@@ -2,11 +2,14 @@
 // Provide a plugin which others can use it in Nuxt as no ssr mode.
 // Usage in Nuxt: https://nuxtjs.org/guide/plugins/#client-side-only
 
+import Vue from 'vue'
 import RplImageGalleryModal from './ImageGalleryModal.vue'
 import RplFullscreenImage from './FullscreenImage.vue'
 import RplImageGallery from './ImageGallery.vue'
 import RplComplexImage from './ComplexImage.vue'
+const RplImageGalleryBus = new Vue()
 
+export { RplImageGalleryBus }
 export { RplImageGalleryModal }
 export { RplFullscreenImage }
 export { RplImageGallery }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-4106

### Changed

1.  Added quickexit to imagegallerymodal component. So when it gets full screen it will have its own one. Also, this will fix the IE11 issue, where before it wasn't rendering one from the page layout in the modal.
2. Added condition in page layout quickexiit component to check whether modal is open or not.
3. Updated the ImageGallery component. Removed the openModal method, instead of added modalToggle method to open and close the modal. This will help to pass the value to PageLayout component using the event bus.
4. Added `RplImageGalleryEventBus`.

### Screenshots

Screenshot from IE11 - 
<
![image](https://user-images.githubusercontent.com/20810541/87013706-69e27180-c20e-11ea-9cdc-706ac2782fc9.png)
!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
