### PR TITLE
[SDPA-4466] Added new var to capture robots meta from page header.

### DIFF
--- a/packages/ripple-nuxt-tide/lib/core/tide-helper.js
+++ b/packages/ripple-nuxt-tide/lib/core/tide-helper.js
@@ -128,7 +128,7 @@ export const getPageHeadConfig = ({
       { name: 'sitesection', content: siteSectionName },
       { name: 'content-type', content: pageType && pageType.replace('node--', '') },
       // Robots meta
-      robotsMeta ? { name: 'robots', content: robotsMeta } : ''
+      { name: 'robots', content: robotsMeta }
     ]
   }
 }

--- a/packages/ripple-nuxt-tide/lib/core/tide-helper.js
+++ b/packages/ripple-nuxt-tide/lib/core/tide-helper.js
@@ -128,7 +128,7 @@ export const getPageHeadConfig = ({
       { name: 'sitesection', content: siteSectionName },
       { name: 'content-type', content: pageType && pageType.replace('node--', '') },
       // Robots meta
-      { name: 'robots', content: robotsMeta }
+      robotsMeta ? { name: 'robots', content: robotsMeta } : ''
     ]
   }
 }

--- a/packages/ripple-nuxt-tide/lib/core/tide-helper.js
+++ b/packages/ripple-nuxt-tide/lib/core/tide-helper.js
@@ -90,7 +90,7 @@ export const stringToClass = (str) => {
  * @param {string} pageHead.imageAlt - Social sharing image alt text.
  * @param {string} pageHead.siteSectionName - Page site section name.
  * @param {string} pageHead.pageType - Page content type.
- * @param {string} pageHead.robotsNoIndex - Robots meta type.
+ * @param {string} pageHead.robotsMeta - Robots meta type.
  * @return {Object} pageHead, can be used in store tide/setPageHead.
  */
 export const getPageHeadConfig = ({
@@ -102,7 +102,7 @@ export const getPageHeadConfig = ({
   imageAlt,
   siteSectionName = '',
   pageType,
-  robotsNoIndex
+  robotsMeta
 }) => {
   return {
     htmlAttrs: {
@@ -128,7 +128,7 @@ export const getPageHeadConfig = ({
       { name: 'sitesection', content: siteSectionName },
       { name: 'content-type', content: pageType && pageType.replace('node--', '') },
       // Robots meta
-      robotsNoIndex ? { name: 'robots', content: robotsNoIndex } : ''
+      robotsMeta ? { name: 'robots', content: robotsMeta } : ''
     ]
   }
 }

--- a/packages/ripple-nuxt-tide/lib/core/tide-helper.js
+++ b/packages/ripple-nuxt-tide/lib/core/tide-helper.js
@@ -104,7 +104,7 @@ export const getPageHeadConfig = ({
   pageType,
   robotsMeta
 }) => {
-  return {
+  const head = {
     htmlAttrs: {
       lang: langcode
     },
@@ -126,9 +126,13 @@ export const getPageHeadConfig = ({
       { name: 'twitter:image:alt', hid: 'hid:image:alt', content: imageAlt },
       // Custom page meta
       { name: 'sitesection', content: siteSectionName },
-      { name: 'content-type', content: pageType && pageType.replace('node--', '') },
-      // Robots meta
-      robotsMeta ? { name: 'robots', content: robotsMeta } : ''
+      { name: 'content-type', content: pageType && pageType.replace('node--', '') }
     ]
   }
+  if (robotsMeta) {
+    // Robots meta
+    let robotsMetaTag = { name: 'robots', content: robotsMeta }
+    head.meta.push(robotsMetaTag)
+  }
+  return head
 }

--- a/packages/ripple-nuxt-tide/lib/core/tide-helper.js
+++ b/packages/ripple-nuxt-tide/lib/core/tide-helper.js
@@ -90,6 +90,7 @@ export const stringToClass = (str) => {
  * @param {string} pageHead.imageAlt - Social sharing image alt text.
  * @param {string} pageHead.siteSectionName - Page site section name.
  * @param {string} pageHead.pageType - Page content type.
+ * @param {string} pageHead.robotsNoIndex - Robots meta type.
  * @return {Object} pageHead, can be used in store tide/setPageHead.
  */
 export const getPageHeadConfig = ({
@@ -100,7 +101,8 @@ export const getPageHeadConfig = ({
   image,
   imageAlt,
   siteSectionName = '',
-  pageType
+  pageType,
+  robotsNoIndex
 }) => {
   return {
     htmlAttrs: {
@@ -124,7 +126,9 @@ export const getPageHeadConfig = ({
       { name: 'twitter:image:alt', hid: 'hid:image:alt', content: imageAlt },
       // Custom page meta
       { name: 'sitesection', content: siteSectionName },
-      { name: 'content-type', content: pageType && pageType.replace('node--', '') }
+      { name: 'content-type', content: pageType && pageType.replace('node--', '') },
+      // Robots meta
+      robotsNoIndex ? { name: 'robots', content: robotsNoIndex } : ''
     ]
   }
 }

--- a/packages/ripple-nuxt-tide/lib/middleware/page-head.js
+++ b/packages/ripple-nuxt-tide/lib/middleware/page-head.js
@@ -22,6 +22,9 @@ const tidePageHead = (context, pageData) => {
     const image = mediaImage ? mediaImage.url : `${context.store.state.tide.protocol + '//' + context.store.state.tide.host}/img/social-media-image.jpg`
     const imageAlt = mediaImage ? mediaImage.meta.alt : ''
 
+    // Set robots
+    const robotsMeta = pageData.tidePage.appMetatag.robots ? pageData.tidePage.appMetatag.robots : ''
+
     const headData = {
       langcode: pageData.tidePage.langcode,
       title,
@@ -31,7 +34,7 @@ const tidePageHead = (context, pageData) => {
       image,
       imageAlt,
       pageType: pageData.tidePage.type,
-      robotsMeta: pageData.tidePage.appMetatag.robots
+      robotsMeta
     }
 
     context.store.dispatch('tide/setPageHead', getPageHeadConfig(headData))

--- a/packages/ripple-nuxt-tide/lib/middleware/page-head.js
+++ b/packages/ripple-nuxt-tide/lib/middleware/page-head.js
@@ -31,7 +31,7 @@ const tidePageHead = (context, pageData) => {
       image,
       imageAlt,
       pageType: pageData.tidePage.type,
-      robotsNoIndex: pageData.tidePage.appMetatag.robots
+      robotsMeta: pageData.tidePage.appMetatag.robots
     }
 
     context.store.dispatch('tide/setPageHead', getPageHeadConfig(headData))

--- a/packages/ripple-nuxt-tide/lib/middleware/page-head.js
+++ b/packages/ripple-nuxt-tide/lib/middleware/page-head.js
@@ -30,7 +30,8 @@ const tidePageHead = (context, pageData) => {
       siteSectionName: siteSection ? siteSection.name : '',
       image,
       imageAlt,
-      pageType: pageData.tidePage.type
+      pageType: pageData.tidePage.type,
+      robotsNoIndex: pageData.tidePage.appMetatag.robots
     }
 
     context.store.dispatch('tide/setPageHead', getPageHeadConfig(headData))

--- a/packages/ripple-nuxt-tide/test/unit/tide.test.js
+++ b/packages/ripple-nuxt-tide/test/unit/tide.test.js
@@ -110,6 +110,80 @@ describe('tide helpers', () => {
     expect(metatag2).toEqual({})
   })
 
+  test('should able to get header config', () => {
+    const headData = {
+      langcode: 'en',
+      title: 'Test title',
+      description: 'Test description',
+      url: 'https://www.vic.gov.au',
+      image: 'https://www.vic.gov.au/Melbourne-tram.jpg',
+      imageAlt: 'Demo: Melbourne tram',
+      siteSectionName: '',
+      pageType: 'landing_page',
+      robotsMeta: 'noindex'
+    }
+
+    const result = {
+      htmlAttrs: { lang: 'en' },
+      title: 'Test title',
+      meta: [
+        {
+          name: 'description',
+          hid: 'description',
+          content: 'Test description'
+        },
+        { name: 'og:title', hid: 'og:title', content: 'Test title' },
+        {
+          name: 'og:description',
+          hid: 'og:description',
+          content: 'Test description'
+        },
+        { name: 'og:type', hid: 'og:type', content: 'website' },
+        {
+          name: 'og:url',
+          hid: 'og:url',
+          content: 'https://www.vic.gov.au'
+        },
+        {
+          name: 'og:image',
+          hid: 'og:image',
+          content: 'https://www.vic.gov.au/Melbourne-tram.jpg'
+        },
+        { name: 'twitter:card', hid: 'twitter:card', content: 'summary' },
+        {
+          name: 'twitter:site',
+          hid: 'twitter:site',
+          content: 'https://www.vic.gov.au'
+        },
+        {
+          name: 'twitter:title',
+          hid: 'twitter:title',
+          content: 'Test title'
+        },
+        {
+          name: 'twitter:description',
+          hid: 'twitter:description',
+          content: 'Test description'
+        },
+        {
+          name: 'twitter:image',
+          hid: 'twitter:image',
+          content: 'https://www.vic.gov.au/Melbourne-tram.jpg'
+        },
+        {
+          name: 'twitter:image:alt',
+          hid: 'hid:image:alt',
+          content: 'Demo: Melbourne tram'
+        },
+        { name: 'sitesection', content: '' },
+        { name: 'content-type', content: 'landing_page' },
+        { name: 'robots', content: 'noindex' }
+      ]
+    }
+    const headconfig = helper.getPageHeadConfig(headData)
+    expect(headconfig).toEqual(result)
+  })
+
   describe('pathToClass', () => {
     /* eslint-disable indent */
     test.each`


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** Parent ticket - https://digital-engagement.atlassian.net/browse/SDPA-4457
                         Subtask - https://digital-engagement.atlassian.net/browse/SDPA-4466

### Issue
The grant nodes that get created during the feed, should not be indexed by google and also shouldn't get added to the sitemap.

### Changed

1. Added robotsMeta in the page-head.js to capture the robot's meta content from BE.
2. Added robotsMeta in tide-helper.js to render it the page header if it exists.

### Related PRs
FE PR Env link - ([Click Here](https://app-ripple-pr-731.lagoon.vicsdp.amazee.io/))
BE PR - https://github.com/dpc-sdp/tide_grant/pull/5
Content-vic PR for testing - https://github.com/dpc-sdp/content-vic-gov-au/pull/908 ([Env Link](https://nginx-php-content-vic-pr-908.lagoon.vicsdp.amazee.io/))

### Screenshots
When there is robot content - 
<img width="965" alt="Screen Shot 2020-07-21 at 7 34 29 pm" src="https://user-images.githubusercontent.com/20810541/88038235-4a8e0180-cb89-11ea-9c66-90a5e176e000.png">

When there is no robot content - 
<img width="961" alt="Screen Shot 2020-07-21 at 7 35 30 pm" src="https://user-images.githubusercontent.com/20810541/88038344-6ee9de00-cb89-11ea-9f09-191eaaf65805.png">

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
