### PR TITLE
[SDPA-4106] Added quickexit fix for image gallery modal and IE.

### DIFF
--- a/packages/components/Molecules/Layout/QuickExit.vue
+++ b/packages/components/Molecules/Layout/QuickExit.vue
@@ -105,7 +105,7 @@ export default {
       @include rpl_narrow_button_danger;
 
       &--stickable {
-        z-index: $rpl-zindex-header;
+        z-index: $rpl-zindex-popover;
         top: $rpl-header-horizontal-padding-xs;
         right: $rpl-header-horizontal-padding-xs;
 

--- a/packages/components/Organisms/ImageGallery/ImageGalleryModal.vue
+++ b/packages/components/Organisms/ImageGallery/ImageGalleryModal.vue
@@ -92,11 +92,11 @@ export default {
       cursor: pointer;
       z-index: 1;
       top: $rpl-image-gallery-modal-edge-margin-s;
-      right: $rpl-image-gallery-modal-edge-margin-s;
+      left: $rpl-image-gallery-modal-edge-margin-s;
 
       @include rpl-breakpoint('l') {
         top: $rpl-image-gallery-modal-edge-margin-l;
-        right: $rpl-image-gallery-modal-edge-margin-l;
+        left: $rpl-image-gallery-modal-edge-margin-l;
       }
 
       svg {


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-4106

### Changed

1.  Moved close button for image gallery modal from the right side to the left side to avoid overlapping with quick exit button.
2. Changed the z-index for "quick exit" to fix the IE issue. The image gallery modal z-index was higher than the "quick exit" z-index value, which was causing it to hide in IE.

### Screenshots
<img width="1440" alt="Screen Shot 2020-08-10 at 11 33 01 am" src="https://user-images.githubusercontent.com/20810541/89746681-5d4b8480-dafe-11ea-85f3-5ebd6b7804cd.png">

!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
