### PR TITLE
[SDPA-4624] Change CTA img fit to contain

### DIFF
--- a/packages/components/Atoms/ResponsiveImg/ResponsiveImg.vue
+++ b/packages/components/Atoms/ResponsiveImg/ResponsiveImg.vue
@@ -1,5 +1,5 @@
 <template>
-  <img v-if="src" class="rpl-responsive-image" :alt="alt" :height="height" :width="width" ref="image" :src="src" :srcset="calcSrcSet" :sizes="calcSizes" :style="calcFocalPoint"  />
+  <img v-if="src" class="rpl-responsive-image" :class="`rpl-responsive-image--fit-${fit}`" :alt="alt" :height="height" :width="width" ref="image" :src="src" :srcset="calcSrcSet" :sizes="calcSizes" :style="calcFocalPoint"  />
 </template>
 
 <script>
@@ -40,6 +40,11 @@ export default {
     },
     width: {
       type: Number
+    },
+    fit: {
+      type: String,
+      default: 'cover',
+      validator: val => ['cover', 'contain'].includes(val)
     }
   },
   mounted () {
@@ -107,6 +112,11 @@ export default {
 
   .rpl-responsive-image {
     width: 100%;
-    @include object_fit_image(cover);
+    &--fit-cover {
+      @include object_fit_image(cover);
+    }
+    &--fit-contain {
+      @include object_fit_image(contain);
+    }
   }
 </style>

--- a/packages/components/Atoms/ResponsiveImg/__snapshots__/stories.storyshot
+++ b/packages/components/Atoms/ResponsiveImg/__snapshots__/stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`RippleStoryshots Atoms/ResponsiveImg Default 1`] = `
 <img
-  class="rpl-responsive-image"
+  class="rpl-responsive-image rpl-responsive-image--fit-cover"
   sizes="100vw"
   src="https://images.unsplash.com/photo-1591302418462-eb55463b49d6"
   srcset="https://images.unsplash.com/photo-1591302418462-eb55463b49d6?w=575&h=300 575w, https://images.unsplash.com/photo-1591302418462-eb55463b49d6?w=768&h=600 768w, https://images.unsplash.com/photo-1591302418462-eb55463b49d6?w=992&h=600 992w, https://images.unsplash.com/photo-1591302418462-eb55463b49d6?w=1600&h=600 1600w"

--- a/packages/components/Molecules/Card/__snapshots__/stories.storyshot
+++ b/packages/components/Molecules/Card/__snapshots__/stories.storyshot
@@ -1086,7 +1086,7 @@ exports[`RippleStoryshots Molecules/Card/Card Content (base) Default 1`] = `
   >
     <img
       alt=""
-      class="rpl-responsive-image rpl-card-content__image"
+      class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
       height="340"
       src="https://placehold.it/580x340"
       style="object-position: 50.00% 50.00%; font-family: 'object-fit: cover; object-position: 50.00% 50.00%;';"
@@ -1141,7 +1141,7 @@ exports[`RippleStoryshots Molecules/Card/Card Cta Default 1`] = `
   >
     <img
       alt=""
-      class="rpl-responsive-image rpl-card-cta__image"
+      class="rpl-responsive-image rpl-card-cta__image rpl-responsive-image--fit-cover"
       height="148"
       src="https://placehold.it/148x148"
       style="object-position: 100% 100%; font-family: 'object-fit: cover; object-position: 100% 100%;';"
@@ -1249,7 +1249,7 @@ exports[`RippleStoryshots Molecules/Card/Card Event Default 1`] = `
   >
     <img
       alt=""
-      class="rpl-responsive-image rpl-card-content__image"
+      class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
       height="199"
       src="https://placehold.it/304x199"
       style="object-position: 50.00% 50.25%; font-family: 'object-fit: cover; object-position: 50.00% 50.25%;';"
@@ -1327,7 +1327,7 @@ exports[`RippleStoryshots Molecules/Card/Card Image Navigation Default 1`] = `
   >
     <img
       alt=""
-      class="rpl-responsive-image rpl-card-content__image"
+      class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
       height="199"
       src="https://placehold.it/304x199"
       style="object-position: 50.00% 50.25%; font-family: 'object-fit: cover; object-position: 50.00% 50.25%;';"
@@ -1538,7 +1538,7 @@ exports[`RippleStoryshots Molecules/Card/Card Navigation Featured Default 1`] = 
   >
     <img
       alt=""
-      class="rpl-responsive-image rpl-card-navigation-featured__image"
+      class="rpl-responsive-image rpl-card-navigation-featured__image rpl-responsive-image--fit-cover"
       height="497"
       src="https://placehold.it/818x497"
       style="object-position: 50.00% 49.90%; font-family: 'object-fit: cover; object-position: 50.00% 49.90%;';"
@@ -1668,7 +1668,7 @@ exports[`RippleStoryshots Molecules/Card/Card Promotion Default 1`] = `
   >
     <img
       alt=""
-      class="rpl-responsive-image rpl-card-content__image"
+      class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
       height="199"
       src="https://placehold.it/304x199"
       style="object-position: 50.00% 50.25%; font-family: 'object-fit: cover; object-position: 50.00% 50.25%;';"

--- a/packages/components/Molecules/Search/__snapshots__/stories.storyshot
+++ b/packages/components/Molecules/Search/__snapshots__/stories.storyshot
@@ -84,7 +84,7 @@ exports[`RippleStoryshots Molecules/Search/Legacy search results Card Search Res
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -150,7 +150,7 @@ exports[`RippleStoryshots Molecules/Search/Legacy search results Card Search Res
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -278,7 +278,7 @@ exports[`RippleStoryshots Molecules/Search/Legacy search results Card Search Res
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>

--- a/packages/components/Organisms/CallToAction/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/CallToAction/__snapshots__/stories.storyshot
@@ -2,56 +2,121 @@
 
 exports[`RippleStoryshots Organisms/CallToAction Call to Action 1`] = `
 <div
-  class="rpl-call-to-action"
+  class="rpl-content"
 >
   <div
-    class="rpl-call-to-action__row"
+    class="rpl-call-to-action"
   >
     <div
-      class="rpl-call-to-action__left"
+      class="rpl-call-to-action__row"
     >
-      <img
-        alt=""
-        class="rpl-responsive-image rpl-call-to-action__image"
-        src="http://placehold.it/336x249"
-      />
-    </div>
-     
-    <div
-      class="rpl-call-to-action__right"
-    >
-      <h2
-        class="rpl-call-to-action__title"
-      >
-        Card prompting an action
-      </h2>
-       
       <div
-        class="rpl-call-to-action__summary"
+        class="rpl-call-to-action__left"
       >
-        <p>
-          Sed ut 
-          <b>
-            perspiciatis
-          </b>
-           unde omnis iste natus error sit voluptatem accusantium dolore que laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-        </p>
-        <p>
-          Nemo enim ipsam voluptatem.
-        </p>
+        <img
+          alt=""
+          class="rpl-responsive-image rpl-call-to-action__image rpl-responsive-image--fit-contain"
+          src="http://placehold.it/336x249"
+        />
       </div>
        
-      <a
-        class="rpl-link rpl-button rpl-button--primary"
-        data-print-url="#"
-        href="#"
+      <div
+        class="rpl-call-to-action__right"
       >
-        <span
-          class="rpl-link__inner"
+        <h2
+          class="rpl-call-to-action__title"
         >
-          Call to action
-        </span>
-      </a>
+          Card prompting an action
+        </h2>
+         
+        <div
+          class="rpl-call-to-action__summary"
+        >
+          <p>
+            Sed ut 
+            <b>
+              perspiciatis
+            </b>
+             unde omnis iste natus error sit voluptatem accusantium dolore que laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          </p>
+          <p>
+            Nemo enim ipsam voluptatem.
+          </p>
+        </div>
+         
+        <a
+          class="rpl-link rpl-button rpl-button--primary"
+          data-print-url="#"
+          href="#"
+        >
+          <span
+            class="rpl-link__inner"
+          >
+            Call to action
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RippleStoryshots Organisms/CallToAction without sidebar 1`] = `
+<div
+  class="rpl-content"
+>
+  <div
+    class="rpl-call-to-action rpl-call-to-action--without-sidebar"
+  >
+    <div
+      class="rpl-call-to-action__row"
+    >
+      <div
+        class="rpl-call-to-action__left"
+      >
+        <img
+          alt=""
+          class="rpl-responsive-image rpl-call-to-action__image rpl-responsive-image--fit-contain"
+          src="http://placehold.it/336x249"
+        />
+      </div>
+       
+      <div
+        class="rpl-call-to-action__right"
+      >
+        <h2
+          class="rpl-call-to-action__title"
+        >
+          Card prompting an action
+        </h2>
+         
+        <div
+          class="rpl-call-to-action__summary"
+        >
+          <p>
+            Sed ut 
+            <b>
+              perspiciatis
+            </b>
+             unde omnis iste natus error sit voluptatem accusantium dolore que laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          </p>
+          <p>
+            Nemo enim ipsam voluptatem.
+          </p>
+        </div>
+         
+        <a
+          class="rpl-link rpl-button rpl-button--primary"
+          data-print-url="#"
+          href="#"
+        >
+          <span
+            class="rpl-link__inner"
+          >
+            Call to action
+          </span>
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/Organisms/CallToAction/index.vue
+++ b/packages/components/Organisms/CallToAction/index.vue
@@ -2,7 +2,7 @@
   <div class="rpl-call-to-action" v-bind:class="{'rpl-call-to-action__no-image': !image}">
     <div class="rpl-call-to-action__row">
       <div class="rpl-call-to-action__left" v-if="image">
-        <rpl-responsive-img class="rpl-call-to-action__image" v-bind="image" :alt="image.alt" />
+        <rpl-responsive-img class="rpl-call-to-action__image" v-bind="image" fit="contain" :srcSet="[{ size: 'xs', height: 249, width: 336 }]" :alt="image.alt" />
       </div>
       <div class="rpl-call-to-action__right">
         <h2 v-if="title" class="rpl-call-to-action__title">{{ title }}</h2>
@@ -63,7 +63,7 @@ export default {
   $rpl-call-to-action-summary-text-color: mix(rpl_color('extra_dark_neutral'), rpl_color('white'), 93%) !default;
   $rpl-call-to-action-summary-margin-xs: $rpl-space-3 0 !default;
   $rpl-call-to-action-summary-margin-s: ($rpl-space * 6) 0 !default;
-  $rpl-call-to-action-image-height: 300px !default;
+  $rpl-call-to-action-image-max-height: 400px !default;
 
 .rpl-content {
   .rpl-call-to-action {
@@ -73,8 +73,9 @@ export default {
     border: $rpl-call-to-action-border;
 
     &__image {
-      width: 100%;
-      max-height: $rpl-call-to-action-image-height;
+      width: auto;
+      max-width: 100%;
+      max-height: $rpl-call-to-action-image-max-height;
     }
 
     &__no-image {

--- a/packages/components/Organisms/CallToAction/stories.js
+++ b/packages/components/Organisms/CallToAction/stories.js
@@ -11,7 +11,25 @@ storiesOf('Organisms/CallToAction', module)
   .addDecorator(withKnobs)
   .add('Call to Action', () => ({
     components: { RplCallToAction },
-    template: `<rpl-call-to-action :title="title" :summary="summary" :link="link" :image="image" />`,
+    template: `<div class="rpl-content"> <rpl-call-to-action :title="title" :summary="summary" :link="link" :image="image" /></div>`,
+    props: {
+      title: {
+        default: text('Title', 'Card prompting an action')
+      },
+      summary: {
+        default: text('Summary', '<p>Sed ut <b>perspiciatis</b> unde omnis iste natus error sit voluptatem accusantium dolore que laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p><p>Nemo enim ipsam voluptatem.</p>')
+      },
+      link: {
+        default: () => object('Call to action', { text: 'Call to action', url: '#' })
+      },
+      image: {
+        default: () => object('Image', { src: 'http://placehold.it/336x249', alt: '' })
+      }
+    }
+  }))
+  .add('without sidebar', () => ({
+    components: { RplCallToAction },
+    template: `<div class="rpl-content"> <rpl-call-to-action class="rpl-call-to-action--without-sidebar" :title="title" :summary="summary" :link="link" :image="image" /></div>`,
     props: {
       title: {
         default: text('Title', 'Card prompting an action')

--- a/packages/components/Organisms/CampaignSecondary/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/CampaignSecondary/__snapshots__/stories.storyshot
@@ -15,7 +15,7 @@ exports[`RippleStoryshots Organisms/CampaignSecondary With image 1`] = `
       >
         <img
           alt=""
-          class="rpl-responsive-image rpl-campaign-secondary__image"
+          class="rpl-responsive-image rpl-campaign-secondary__image rpl-responsive-image--fit-cover"
           height="340"
           src="https://placehold.it/580x340"
           style="object-position: 50.00% 50.00%; font-family: 'object-fit: cover; object-position: 50.00% 50.00%;';"

--- a/packages/components/Organisms/Event/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/Event/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -104,7 +104,7 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -181,7 +181,7 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -258,7 +258,7 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -335,7 +335,7 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-content__image"
+            class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/580x340"
           />
         </div>
@@ -415,7 +415,7 @@ exports[`RippleStoryshots Organisms/Event Latest Events 1`] = `
         >
           <img
             alt=""
-            class="rpl-responsive-image rpl-card-cta__image"
+            class="rpl-responsive-image rpl-card-cta__image rpl-responsive-image--fit-cover"
             src="https://placehold.it/148x148"
           />
            

--- a/packages/components/Organisms/News/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/News/__snapshots__/stories.storyshot
@@ -17,7 +17,7 @@ exports[`RippleStoryshots Organisms/News Featured News 1`] = `
       >
         <img
           alt=""
-          class="rpl-responsive-image rpl-card-navigation-featured__image"
+          class="rpl-responsive-image rpl-card-navigation-featured__image rpl-responsive-image--fit-cover"
           src="https://placehold.it/818x497"
         />
          
@@ -72,7 +72,7 @@ exports[`RippleStoryshots Organisms/News Featured News 1`] = `
       >
         <img
           alt=""
-          class="rpl-responsive-image rpl-card-content__image"
+          class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
           src="https://placehold.it/818x497"
         />
       </div>
@@ -146,7 +146,7 @@ exports[`RippleStoryshots Organisms/News Featured News 1`] = `
       >
         <img
           alt=""
-          class="rpl-responsive-image rpl-card-content__image"
+          class="rpl-responsive-image rpl-card-content__image rpl-responsive-image--fit-cover"
           src="https://placehold.it/818x497"
         />
       </div>


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-

### Changed

1.  Change Call to Action component to contain images instead of cover.
1. Add max height variable `$rpl-call-to-action-image-max-height` for CTA image height - set to 400px default to control massive images

### Screenshots
**XL**
![localhost_6006_iframe html_id=organisms-calltoaction--without-sidebar(XL)](https://user-images.githubusercontent.com/2186721/93840528-10012c00-fcd4-11ea-9278-cea5f2b94785.png)
**L**
![localhost_6006_iframe html_id=organisms-calltoaction--without-sidebar(L)](https://user-images.githubusercontent.com/2186721/93840532-1394b300-fcd4-11ea-9939-7766b005518a.png)
**M**
![localhost_6006_iframe html_id=organisms-calltoaction--without-sidebar(M)](https://user-images.githubusercontent.com/2186721/93840533-142d4980-fcd4-11ea-837a-359e5c98977a.png)
**S**
![localhost_6006_iframe html_id=organisms-calltoaction--without-sidebar(S)](https://user-images.githubusercontent.com/2186721/93840534-155e7680-fcd4-11ea-9d18-65fa85ff0da8.png)
**XS Mobile**
![localhost_6006_iframe html_id=organisms-calltoaction--without-sidebar(iPhone X)](https://user-images.githubusercontent.com/2186721/93840535-155e7680-fcd4-11ea-96b0-c587f915003d.png)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
