### PR TITLE
Site Header Dividers and Focus outline improvements.

### DIFF
--- a/packages/components/Organisms/SiteHeader/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/SiteHeader/__snapshots__/stories.storyshot
@@ -30,10 +30,8 @@ exports[`RippleStoryshots Organisms/SiteHeader Site Header 1`] = `
             >
               <!---->
                
-              <div
-                class="rpl-site-header__divider rpl-site-header__divider--vic rpl-site-header__divider--111"
-              />
-
+              <!---->
+               
               <div
                 class="rpl-site-header__title rpl-site-header__logo-container--vic-logo-primary rpl-site-header__logo-container--vic-logo-primary--cobrand"
               >
@@ -54,9 +52,9 @@ exports[`RippleStoryshots Organisms/SiteHeader Site Header 1`] = `
               </div>
                
               <div
-                class="rpl-site-header__divider rpl-site-header__divider--cobrand rpl-site-header__divider--111"
+                class="rpl-site-header__divider rpl-site-header__divider--cobrand rpl-site-header__divider--011"
               />
-
+               
               <div
                 class="rpl-site-header__title"
               >

--- a/packages/components/Organisms/SiteHeader/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/SiteHeader/__snapshots__/stories.storyshot
@@ -31,6 +31,10 @@ exports[`RippleStoryshots Organisms/SiteHeader Site Header 1`] = `
               <!---->
                
               <div
+                class="rpl-site-header__divider rpl-site-header__divider--vic rpl-site-header__divider--has-both"
+              />
+
+              <div
                 class="rpl-site-header__title rpl-site-header__logo-container--vic-logo-primary rpl-site-header__logo-container--vic-logo-primary--cobrand"
               >
                 <a
@@ -49,6 +53,10 @@ exports[`RippleStoryshots Organisms/SiteHeader Site Header 1`] = `
                 </a>
               </div>
                
+              <div
+                class="rpl-site-header__divider rpl-site-header__divider--cobrand rpl-site-header__divider--has-both"
+              />
+
               <div
                 class="rpl-site-header__title"
               >

--- a/packages/components/Organisms/SiteHeader/__snapshots__/stories.storyshot
+++ b/packages/components/Organisms/SiteHeader/__snapshots__/stories.storyshot
@@ -31,7 +31,7 @@ exports[`RippleStoryshots Organisms/SiteHeader Site Header 1`] = `
               <!---->
                
               <div
-                class="rpl-site-header__divider rpl-site-header__divider--vic rpl-site-header__divider--has-both"
+                class="rpl-site-header__divider rpl-site-header__divider--vic rpl-site-header__divider--111"
               />
 
               <div
@@ -54,7 +54,7 @@ exports[`RippleStoryshots Organisms/SiteHeader Site Header 1`] = `
               </div>
                
               <div
-                class="rpl-site-header__divider rpl-site-header__divider--cobrand rpl-site-header__divider--has-both"
+                class="rpl-site-header__divider rpl-site-header__divider--cobrand rpl-site-header__divider--111"
               />
 
               <div

--- a/packages/components/Organisms/SiteHeader/index.vue
+++ b/packages/components/Organisms/SiteHeader/index.vue
@@ -26,14 +26,14 @@
               </button>
               <div class="rpl-site-header__divider rpl-site-header__divider--vic" :class="dividerStateClass"></div>
               <!-- Primary vic.gov.au Logo -->
-              <div v-if="!menuContentOpen && this.rplOptions.viclogo" class="rpl-site-header__title rpl-site-header__logo-container--vic-logo-primary" :class = "{'rpl-site-header__logo-container--vic-logo-primary--cobrand' : (logo)}"> <!--Only apply vic-logo cobrand class if there is a coBrand logo-->
+              <div v-if="vicLogoVisible" class="rpl-site-header__title rpl-site-header__logo-container--vic-logo-primary" :class = "{'rpl-site-header__logo-container--vic-logo-primary--cobrand' : (logo)}"> <!--Only apply vic-logo cobrand class if there is a coBrand logo-->
                 <rpl-link :href="vicLogoPrimary.url">
                   <img :src="vicLogoPrimary.image" :alt="vicLogoPrimary.alt" />
                 </rpl-link>
               </div>
               <div class="rpl-site-header__divider rpl-site-header__divider--cobrand" :class="dividerStateClass"></div>
               <!--Co brand logo if it exists-->
-              <div v-if="!menuContentOpen && logo" class="rpl-site-header__title"> <!--Render element if taxonomy includes a cobrand logo-->
+              <div v-if="cobrandVisible" class="rpl-site-header__title"> <!--Render element if taxonomy includes a cobrand logo-->
                 <rpl-link :href="logo.url">
                   <img :src="logo.image" :alt="logo.alt" />
                 </rpl-link>
@@ -199,7 +199,8 @@ export default {
       this.menuState = this.menuContentOpen ? 'opened' : 'closed'
     },
     showMenuBtn: function () {
-      if (this.menuState === 'opened' && this.searchState !== 'opened' && this.menulinks > 0) {
+      const menuLinkCount = (Array.isArray(this.links) && this.links.length > 0)
+      if (this.menuState === 'opened' && this.searchState !== 'opened' && menuLinkCount) {
         return true
       } else if (this.menuLayout === 'vertical' && this.searchState !== 'opened') {
         return true
@@ -271,24 +272,17 @@ export default {
     }
   },
   computed: {
-    menulinks: function () {
-      // This checks if a site has header menu links.
-      let linkLength = (typeof this.links !== 'undefined') ? this.links.length : 0
-      return linkLength
+    vicLogoVisible () {
+      return (!this.menuContentOpen && this.rplOptions.viclogo)
+    },
+    cobrandVisible () {
+      return (!this.menuContentOpen && this.logo)
     },
     dividerStateClass () {
-      const dividerClass = 'rpl-site-header__divider'
-      const isVicLogo = this.rplOptions.viclogo
-      const isCobrandLogo = this.logo
-      if (isVicLogo && isCobrandLogo) {
-        return `${dividerClass}--has-both`
-      } else if (isVicLogo) {
-        return `${dividerClass}--has-vic-only`
-      } else if (isCobrandLogo) {
-        return `${dividerClass}--has-cobrand-only`
-      } else {
-        return null
-      }
+      const hasMenu = this.menuToggleVisible ? `1` : `0`
+      const hasVic = this.vicLogoVisible ? `1` : `0`
+      const hasCobrand = this.cobrandVisible ? `1` : `0`
+      return `rpl-site-header__divider--${hasMenu}${hasVic}${hasCobrand}`
     }
   },
   mounted: function () {
@@ -414,18 +408,18 @@ export default {
       &--vic {
         display: none;
 
-        &#{$divider_root}--has-both {
-          @include rpl_breakpoint('m') {
-            display: block;
-          }
+        &#{$divider_root}--110 {
+          display: block;
 
           @include rpl_breakpoint('l') {
             display: none;
           }
         }
 
-        &#{$divider_root}--has-vic-only {
-          display: block;
+        &#{$divider_root}--111 {
+          @include rpl_breakpoint('m') {
+            display: block;
+          }
 
           @include rpl_breakpoint('l') {
             display: none;
@@ -436,16 +430,22 @@ export default {
       &--cobrand {
         display: none;
 
-        &#{$divider_root}--has-both {
-          display: block;
+        &#{$divider_root}--011 {
+          @include rpl_breakpoint('m') {
+            display: block;
+          }
         }
 
-        &#{$divider_root}--has-cobrand-only {
+        &#{$divider_root}--101 {
           display: block;
 
           @include rpl_breakpoint('l') {
             display: none;
           }
+        }
+
+        &#{$divider_root}--111 {
+          display: block;
         }
       }
     }

--- a/packages/components/Organisms/SiteHeader/index.vue
+++ b/packages/components/Organisms/SiteHeader/index.vue
@@ -24,13 +24,14 @@
                 <rpl-icon :symbol="menuButton[menuState].icon" color="white"></rpl-icon>
                 <span>{{ menuButton[menuState].text }}</span>
               </button>
+              <div class="rpl-site-header__divider rpl-site-header__divider--vic" :class="dividerStateClass"></div>
               <!-- Primary vic.gov.au Logo -->
               <div v-if="!menuContentOpen && this.rplOptions.viclogo" class="rpl-site-header__title rpl-site-header__logo-container--vic-logo-primary" :class = "{'rpl-site-header__logo-container--vic-logo-primary--cobrand' : (logo)}"> <!--Only apply vic-logo cobrand class if there is a coBrand logo-->
                 <rpl-link :href="vicLogoPrimary.url">
                   <img :src="vicLogoPrimary.image" :alt="vicLogoPrimary.alt" />
                 </rpl-link>
               </div>
-
+              <div class="rpl-site-header__divider rpl-site-header__divider--cobrand" :class="dividerStateClass"></div>
               <!--Co brand logo if it exists-->
               <div v-if="!menuContentOpen && logo" class="rpl-site-header__title"> <!--Render element if taxonomy includes a cobrand logo-->
                 <rpl-link :href="logo.url">
@@ -274,6 +275,20 @@ export default {
       // This checks if a site has header menu links.
       let linkLength = (typeof this.links !== 'undefined') ? this.links.length : 0
       return linkLength
+    },
+    dividerStateClass () {
+      const dividerClass = 'rpl-site-header__divider'
+      const isVicLogo = this.rplOptions.viclogo
+      const isCobrandLogo = this.logo
+      if (isVicLogo && isCobrandLogo) {
+        return `${dividerClass}--has-both`
+      } else if (isVicLogo) {
+        return `${dividerClass}--has-vic-only`
+      } else if (isCobrandLogo) {
+        return `${dividerClass}--has-cobrand-only`
+      } else {
+        return null
+      }
     }
   },
   mounted: function () {
@@ -319,6 +334,11 @@ export default {
   $rpl-site-header-logout-btn-padding: rem(10px) !default;
   $rpl-site-header-logout-btn-margin: $rpl-space-4 !default;
   $rpl-site-header-logout-btn-icon-margin: 0 0 0 $rpl-space-2 !default;
+  $rpl-site-header-menu-divider-border-right: $rpl-site-header-menu-toggle-border-right !default;
+  $rpl-site-header-menu-divider-margin-xl: 0 $rpl-space-2 !default;
+  $rpl-site-header-menu-divider-margin-l: 0 $rpl-space-4 !default;
+  $rpl-site-header-menu-divider-height-xl: rem(14px) !default;
+  $rpl-site-header-menu-divider-height-l: rem(27px) !default;
 
   .rpl-site-header {
     $root: &;
@@ -380,6 +400,56 @@ export default {
       }
     }
 
+    &__divider {
+      $divider_root: &;
+      height: $rpl-site-header-menu-divider-height-xl;
+      margin: $rpl-site-header-menu-divider-margin-xl;
+      border-right: $rpl-site-header-menu-divider-border-right;
+
+      @include rpl_breakpoint('l') {
+        margin: $rpl-site-header-menu-divider-margin-l;
+        height: $rpl-site-header-menu-divider-height-l;
+      }
+
+      &--vic {
+        display: none;
+
+        &#{$divider_root}--has-both {
+          @include rpl_breakpoint('m') {
+            display: block;
+          }
+
+          @include rpl_breakpoint('l') {
+            display: none;
+          }
+        }
+
+        &#{$divider_root}--has-vic-only {
+          display: block;
+
+          @include rpl_breakpoint('l') {
+            display: none;
+          }
+        }
+      }
+
+      &--cobrand {
+        display: none;
+
+        &#{$divider_root}--has-both {
+          display: block;
+        }
+
+        &#{$divider_root}--has-cobrand-only {
+          display: block;
+
+          @include rpl_breakpoint('l') {
+            display: none;
+          }
+        }
+      }
+    }
+
     &__logo-container {
       &-inner {
         display: flex;
@@ -394,8 +464,7 @@ export default {
 
       img {
         width: $rpl-site-header-logo-width;
-        margin-left: $rpl-site-header-menu-toggle-border-spacing;
-        vertical-align: middle;
+        display: block;
       }
 
       &--vic-logo-primary {
@@ -406,17 +475,12 @@ export default {
         }
 
         &--cobrand {
-
-          padding-right: 0.5rem;
-          border-right: 1px solid #fff;
           display: none;
 
           @include rpl_breakpoint('m') {
             display: block;
           }
-
         }
-
       }
     }
 
@@ -475,18 +539,12 @@ export default {
       @include rpl_focus_dark;
 
       &--menu {
-        padding-right: $rpl-site-header-menu-toggle-border-spacing;
-        border-right: $rpl-site-header-menu-toggle-border-right;
-
         span {
+          padding-left: $rpl-site-header-menu-toggle-border-spacing;
           display: none;
           @include rpl_breakpoint('s') {
             display: block;
           }
-        }
-
-        .rpl-icon {
-          margin: $rpl-site-header-menu-toggle-icon-margin;
         }
       }
 

--- a/packages/components/Organisms/SiteHeader/index.vue
+++ b/packages/components/Organisms/SiteHeader/index.vue
@@ -24,7 +24,7 @@
                 <rpl-icon :symbol="menuButton[menuState].icon" color="white"></rpl-icon>
                 <span>{{ menuButton[menuState].text }}</span>
               </button>
-              <div class="rpl-site-header__divider rpl-site-header__divider--vic" :class="dividerStateClass"></div>
+              <div v-if="showMenuBtn()" class="rpl-site-header__divider rpl-site-header__divider--vic" :class="dividerStateClass"></div>
               <!-- Primary vic.gov.au Logo -->
               <div v-if="vicLogoVisible" class="rpl-site-header__title rpl-site-header__logo-container--vic-logo-primary" :class = "{'rpl-site-header__logo-container--vic-logo-primary--cobrand' : (logo)}"> <!--Only apply vic-logo cobrand class if there is a coBrand logo-->
                 <rpl-link :href="vicLogoPrimary.url">
@@ -279,7 +279,7 @@ export default {
       return (!this.menuContentOpen && this.logo)
     },
     dividerStateClass () {
-      const hasMenu = this.menuToggleVisible ? `1` : `0`
+      const hasMenu = this.showMenuBtn() ? `1` : `0`
       const hasVic = this.vicLogoVisible ? `1` : `0`
       const hasCobrand = this.cobrandVisible ? `1` : `0`
       return `rpl-site-header__divider--${hasMenu}${hasVic}${hasCobrand}`
@@ -410,19 +410,11 @@ export default {
 
         &#{$divider_root}--110 {
           display: block;
-
-          @include rpl_breakpoint('l') {
-            display: none;
-          }
         }
 
         &#{$divider_root}--111 {
           @include rpl_breakpoint('m') {
             display: block;
-          }
-
-          @include rpl_breakpoint('l') {
-            display: none;
           }
         }
       }
@@ -438,10 +430,6 @@ export default {
 
         &#{$divider_root}--101 {
           display: block;
-
-          @include rpl_breakpoint('l') {
-            display: none;
-          }
         }
 
         &#{$divider_root}--111 {


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SW-587

### Changed

Update dividers in site header between menu / vic logo / co-brand logo.
- Logo now sits centred.
- Added div element dividers between menu / vic logo / cobrand logo, removing the right border / padding / margin implementation.
The new implementation means keyboard focus outlines no longer wrap around divider elements and provides more sub-site styling options.

Supports:
- Vic + Co-brand Logo
- Vic only logo
- Co-brand only logo
- Neither logo

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
![Frame 3](https://user-images.githubusercontent.com/12739575/99345039-7a55d780-28e5-11eb-84ea-44969f217470.png)
![focus-indicator-variations](https://user-images.githubusercontent.com/12739575/99960326-ab03a880-2de0-11eb-957a-01d1c0edaf89.png)
![focus-comparison](https://user-images.githubusercontent.com/12739575/99345205-e6d0d680-28e5-11eb-965e-efbc1dc82437.png)

