### PR TITLE
[SDPA-4934] Added error handling for invalid paginated api response

### DIFF
--- a/packages/ripple-nuxt-tide/lib/config/defaults.js
+++ b/packages/ripple-nuxt-tide/lib/config/defaults.js
@@ -14,7 +14,7 @@ const defaults = {
   dynamicComponents: [], // Dynamic components importing for Tide mapping.
   middleware: [],
   markupPlugins: [],
-  proxyTimeout: 60000,
+  proxyTimeout: 30000,
   tideTimeout: 10000,
   tideListingTimeout: 30000,
   searchTemplates: {},

--- a/packages/ripple-nuxt-tide/lib/templates/axios.js
+++ b/packages/ripple-nuxt-tide/lib/templates/axios.js
@@ -20,7 +20,7 @@ export default function ({ $axios, app, res, isDev }) {
       code = error.response.status
     }
 
-    let responseUrl = error.request?.path || error.request?.responseURL || error.config?.url
+    let responseUrl = error.request?.path || error.request?.responseURL || error.config?.url || ''
 
     // Check what kind of request it is.
     const routeRequest = responseUrl.includes('/route?')

--- a/packages/ripple-nuxt-tide/test/unit/tide.test.js
+++ b/packages/ripple-nuxt-tide/test/unit/tide.test.js
@@ -335,6 +335,38 @@ describe('tide', () => {
     expect(data).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
   })
 
+  test('should handle paginated data response error', async () => {
+    mockAxios.$get = jest.fn((url) => {
+      switch (url) {
+        case '/api/v1/test/?p2':
+          return Promise.resolve({
+            'data': [4, 5, 6],
+            'links': {
+              'self': 'https://mockAPI/api/v1/test/?p2',
+              'next': 'https://mockAPI/api/v1/test/?p3',
+              'last': 'https://mockAPI/api/v1/test/?p3'
+            }
+          })
+
+        case '/api/v1/test/?p3' :
+          return Promise.reject(new Error('something bad happened'))
+      }
+    })
+
+    const response = {
+      'data': [1, 2, 3],
+      'links': {
+        'self': 'https://mockAPI/api/v1/test/?p1',
+        'next': 'https://mockAPI/api/v1/test/?p2',
+        'last': 'https://mockAPI/api/v1/test/?p3'
+      }
+    }
+
+    expect.assertions(1)
+    const data = await tideApi.getAllPaginatedData(response, false)
+    expect(data).toBeInstanceOf(Error)
+  })
+
   test('should get tide module enabled status', () => {
     const profileStatus = tideApi.isModuleEnabled('profile')
     expect(profileStatus).toBe(true)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING.md BEFORE CREATING A PR

Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

No need to remove these lines - they are comments.
-->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-4934

Server will die by a lot `ERROR  Failed to get next page data` like below:
```

2021-01-12 01:07:16 [Connect]  INFO  Proxy GET request to https://content.vic.gov.au//api/v1/taxonomy_term/sites , res status code: 200. {"service":"ripple-tide","requestQuery":"site=4","requestId":"7431e551512d0d860a1cc2826797a0b0"}
--
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}
  | 2021-01-12 01:07:17 [Tide]  ERROR  Failed to get next page data
  | TypeError: Cannot read property 'includes' of undefined
  | at module.exports.$axios.onError.error (server.js:20448:38)
  | at interceptors.response.use.error (server.js:20070:56)
  | at process._tickCallback (internal/process/next_tick.js:68:7) {"service":"ripple-tide"}

```

## Changed

<!-- Describe your changes in detail -->

1. Fixed the loop logic by quit loop if next page response has error in it, so we can stop the unexpected loop

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

## How Has This Been Tested?

<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | storybook | e2e | none -->
unit

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've added relevant changes to the documentation.
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] My change requires a template update for create-ripple-app.
- [ ] I have added template update script for next release.
