### PR TITLE
SDPA-5768: Select box accessibility fix.

### DIFF
--- a/packages/components/Molecules/Form/Select.vue
+++ b/packages/components/Molecules/Form/Select.vue
@@ -5,7 +5,7 @@
         class="rpl-select__trigger"
         tabindex="0"
         aria-haspopup="listbox"
-        :aria-labelledby="`${config.fieldId}-rpl-select-trigger ${config.fieldId}-rpl-select-value`"
+        :aria-label="labeledText"
         :aria-expanded="isOpen ? 'true' : false"
         role="button"
         ref="trigger"
@@ -144,6 +144,13 @@ export default {
         return this.selectedTitles.map(itm => truncateText(itm, this.selectedCharLength - 1), ' ...').join('; ')
       } else {
         return truncateText(this.selectedTitles[0], this.selectedCharLength - 1, ' ...')
+      }
+    },
+    labeledText () {
+      if (this.config.placeholder === undefined || this.config.placeholder === '' || this.config.placeholder === 'Select') {
+        return this.config.label
+      } else {
+        return this.config.placeholder
       }
     }
   },

--- a/packages/components/Molecules/Form/Select.vue
+++ b/packages/components/Molecules/Form/Select.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="rpl-select" :class="{'rpl-select--open' : isOpen, 'rpl-select--disabled': disabled }">
+    <span class="rpl-select__label-visually-hidden" :id="`${config.fieldId}-rpl-select-label`">{{config.label}}</span>
     <div class="rpl-select__inner">
       <div
         class="rpl-select__trigger"
         tabindex="0"
         aria-haspopup="listbox"
-        :aria-label="labeledText"
+        :aria-labelledby="`${config.fieldId}-rpl-select-trigger ${config.fieldId}-rpl-select-value  ${config.fieldId}-rpl-select-label`"
         :aria-expanded="isOpen ? 'true' : false"
         role="button"
         ref="trigger"
@@ -144,13 +145,6 @@ export default {
         return this.selectedTitles.map(itm => truncateText(itm, this.selectedCharLength - 1), ' ...').join('; ')
       } else {
         return truncateText(this.selectedTitles[0], this.selectedCharLength - 1, ' ...')
-      }
-    },
-    labeledText () {
-      if (this.config.placeholder === undefined || this.config.placeholder === '' || this.config.placeholder === 'Select') {
-        return this.config.label
-      } else {
-        return this.config.placeholder
       }
     }
   },


### PR DESCRIPTION
## Motivation and Context

For any select box, the screen reader would only provide context if there was a placeholder and no option was selected. When placeholder was not provided the default / selected text would be read which would be difficult to understand. 

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-5768

## Changed

<!-- Describe your changes in detail -->

1. Used the aria-label attribute for the select button which would either provide placeholder or the field label 

### Screenshots
![Screenshot-2021-10-12-at-10-52-19-AM](https://user-images.githubusercontent.com/3881627/136896367-ab7a4fdd-193a-4ddc-9ec9-94f5731b216e.png)


