### PR TITLE
SDPA-5681: Accessibility for links which open in new tab.

### DIFF
--- a/packages/components/Atoms/Link/TextLink.vue
+++ b/packages/components/Atoms/Link/TextLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <rpl-link v-if="url !== null" class="rpl-text-link" :class="{ 'rpl-text-link--underline': underline, 'rpl-text-link--dark': (theme === 'dark') }" :href="url" :target="target" :innerWrap="innerWrap">
+  <rpl-link v-if="url !== null" class="rpl-text-link" :class="{ 'rpl-text-link--underline': underline, 'rpl-text-link--dark': (theme === 'dark') }" :href="url" :innerWrap="innerWrap">
     <rpl-text-label :theme="theme" :size="size" :underline="underline" :emphasis="emphasis">
       <rpl-text-icon :text="textDecoded" :symbol="iconSymbolFinal" :color="iconColor" :placement="iconPlacement" :size="iconSize" />
     </rpl-text-label>
@@ -21,7 +21,6 @@ export default {
     iconSize: { default: 'm', type: String },
     text: { default: null, type: String },
     url: { default: null, type: String },
-    target: { default: '', type: String },
     innerWrap: { default: true, type: Boolean },
     underline: { default: false, type: Boolean },
     theme: { default: 'light', type: String },


### PR DESCRIPTION
## Motivation and Context
WHEN a page contains a button that will take the user to a new tab
THEN the feature is WCAG 2.1 AA compliant and the user hears a title similar to "[Button text] - opens in new tab.

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-5681

## Changed

<!-- Describe your changes in detail -->

1. Added hidden span to rpl-link to indicate when a link opens a new window/tab.

### Screenshots

![image](https://user-images.githubusercontent.com/330601/138006599-14954158-1a61-4243-918e-10576bfbbaaf.png)


