### PR TITLE
[SDPAP-6333] Added alt text to hero banner logos.

### DIFF
--- a/packages/components/Organisms/HeroBanner/HeroBanner.vue
+++ b/packages/components/Organisms/HeroBanner/HeroBanner.vue
@@ -5,7 +5,7 @@
   }" :style="heroBannerStyles">
     <rpl-row v-if="logo">
       <div class="rpl-hero-banner__left">
-        <img class="rpl-hero-banner__logo" :src="logo" alt="" />
+        <img class="rpl-hero-banner__logo" :src="logo.url" :alt="logo.alt" />
       </div>
     </rpl-row>
     <rpl-row>
@@ -95,7 +95,7 @@ export default {
     moreLink: Object,
     theme: { type: String, default: 'light' },
     showLinks: { type: Boolean, default: true },
-    logo: String,
+    logo: Object,
     backgroundGraphic: String
   },
   components: {

--- a/packages/components/Organisms/HeroBanner/heroBanner.stories.mdx
+++ b/packages/components/Organisms/HeroBanner/heroBanner.stories.mdx
@@ -52,7 +52,7 @@ export const Template = (args, { argTypes }) => ({
       moreLink: { text: 'See more', url: '#' },
       theme: 'light',
       showLinks: true,
-      logo: '/herologo.png',
+      logo: { url: '/herologo.png', alt: 'Image of hero logo' },
       backgroundGraphic: '/bggraphiclower.png'
     }}
   >

--- a/packages/ripple-nuxt-tide/lib/middleware/banners.js
+++ b/packages/ripple-nuxt-tide/lib/middleware/banners.js
@@ -22,7 +22,7 @@ const tideBanners = async (context, pageData) => {
   heroBanner.logo = pageData.tidePage.field_landing_page_hero_logo ? {
     url: pageData.tidePage.field_landing_page_hero_logo.field_media_image.url,
     alt: pageData.tidePage.field_landing_page_hero_logo.field_media_image.meta.alt || ''
-  } : {}
+  } : null
 
   if (pageData.tidePage.field_landing_page_hero_image && pageData.tidePage.field_landing_page_hero_image.field_media_image) {
     const mediaImage = pageData.tidePage.field_landing_page_hero_image.field_media_image

--- a/packages/ripple-nuxt-tide/lib/middleware/banners.js
+++ b/packages/ripple-nuxt-tide/lib/middleware/banners.js
@@ -19,7 +19,10 @@ const tideBanners = async (context, pageData) => {
   heroBanner.keyJourneys = pageData.tidePage.field_landing_page_key_journeys || {}
   heroBanner.theme = pageData.tidePage.field_landing_page_hero_theme
   heroBanner.showLinks = !hasImageBanner
-  heroBanner.logo = pageData.tidePage.field_landing_page_hero_logo ? pageData.tidePage.field_landing_page_hero_logo.field_media_image.url : null
+  heroBanner.logo = pageData.tidePage.field_landing_page_hero_logo ? {
+    url: pageData.tidePage.field_landing_page_hero_logo.field_media_image.url,
+    alt: pageData.tidePage.field_landing_page_hero_logo.field_media_image.meta.alt || ''
+  } : {}
 
   if (pageData.tidePage.field_landing_page_hero_image && pageData.tidePage.field_landing_page_hero_image.field_media_image) {
     const mediaImage = pageData.tidePage.field_landing_page_hero_image.field_media_image


### PR DESCRIPTION
## Motivation and Context
Allow alt text to be displayed for hero banner logos (primarily for screen readers).

**JIRA issue:** https://digital-vic.atlassian.net/browse/SDPAP-6333

## Changed
This update displays the logo's alt title in the hero component, this means the logo being passed to `HeroBanner.vue` is now an object instead of a string.

### Screenshots
<img width="651" alt="hero-logo-with-alt-text" src="https://user-images.githubusercontent.com/287178/182273994-5346080f-ae5e-4c66-bcab-2ee41b1e8308.png">

## How Has This Been Tested?
The storybook story has been updated so the logo prop is now an object. https://storybook.pr-1228.ripple.sdp2.sdp.vic.gov.au/?path=/story/organisms-banners--hero-banner

The change can be previewed at the below URLS:
Hero logo with alt text:  https://app.pr-1228.ripple.sdp2.sdp.vic.gov.au/sdpta-all-components-landing-page-fixture
Page with no hero logo:  https://app.pr-1228.ripple.sdp2.sdp.vic.gov.au/embedded-video-test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

#### Note: someone more familiar with the project may be aware of any unforeseen issues around changing the prop type.

## Checklist
- [ ] I've added relevant changes to the documentation.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] My change requires a template update for create-ripple-app.
- [ ] I have added template update script for next release.
