### PR TITLE
[SW-1635] update card collection component

### DIFF
--- a/packages/ripple-nuxt-tide/modules/landing-page/lib/card-collection-utils.js
+++ b/packages/ripple-nuxt-tide/modules/landing-page/lib/card-collection-utils.js
@@ -4,46 +4,46 @@
  * @param {Object} settings Settings from card collection
  * @returns {Object} queryParams to pass to pass to tideSearchApi
  */
-export const getQueryParams = (settings) => {
-  if (settings) {
+export const getQueryParams = (data) => {
+  const config = data.hasOwnProperty('config') ? data.config : data
+  if (config) {
     const queryParams = {
-      type: settings.content_type || 'all'
+      type: config.content_type || 'all'
     }
 
-    if (settings.filters) {
-      delete settings.filters.type
-      queryParams.filters = settings.filters
+    if (config.filters) {
+      delete config.filters.type
+      queryParams.filters = config.filters
     }
 
-    if (settings.sort && settings.sort.field !== '') {
-      queryParams.sort = [{ [`${settings.sort.field}`]: settings.sort.direction }]
+    if (config.sort && config.sort.field !== '') {
+      queryParams.sort = [{ [`${config.sort.field}`]: config.sort.direction }]
     }
 
-    if (settings.sort && settings.sort.field) {
-      queryParams.sort = [{ [`${settings.sort.field}`]: settings.sort.direction }]
+    if (config.sort && config.sort.field) {
+      queryParams.sort = [{ [`${config.sort.field}`]: config.sort.direction }]
     }
 
-    if (settings.filter_today && settings.filter_today.status) {
+    if (config.filter_today && config.filter_today.status) {
       queryParams.date_filter = {
-        start_field: settings.filter_today.start_date,
-        end_field: settings.filter_today.end_date,
-        criteria: settings.filter_today.criteria
+        start_field: config.filter_today.start_date,
+        end_field: config.filter_today.end_date,
+        criteria: config.filter_today.criteria
       }
     }
 
     const carouselLimit = 9
 
-    if (settings.display) {
-      if (settings.display.type === 'grid' && settings.display.items_per_page) {
-        queryParams.limit = settings.display.items_per_page
-      } else if (settings.display.items_per_page && settings.display.items_per_page !== 0 && settings.display.items_per_page < carouselLimit) {
-        queryParams.limit = settings.display.items_per_page
-      } else {
-        queryParams.limit = carouselLimit
-      }
+    if (config.field_listing_display_type === 'grid' && config.perPage) {
+      queryParams.limit = config.perPage
+    } else if (data.perPage && data.perPage !== 0 && data.perPage < carouselLimit) {
+      queryParams.limit = data.perPage
+    } else {
+      queryParams.limit = carouselLimit
     }
-    if (settings.page) {
-      queryParams.page = settings.page
+
+    if (config.page) {
+      queryParams.page = config.page
     }
 
     return queryParams

--- a/packages/ripple-nuxt-tide/modules/landing-page/tide.config.js
+++ b/packages/ripple-nuxt-tide/modules/landing-page/tide.config.js
@@ -446,12 +446,12 @@ module.exports = {
         component: 'automated-card-listing',
         props: {
           title: 'field_paragraph_title',
-          cardCtaText: 'field_paragraph_cta_text',
           config: ['field_paragraph_auto_listing'],
-          ctaLink: {
-            field: 'field_paragraph_cta',
-            filters: ['paragraphCta']
-          }
+          perPage: ['field_listings_per_page'],
+          minimum: ['field_listings_minimum'],
+          displayType: ['field_listing_display_type'],
+          noResultsMessage: ['field_no_results_message'],
+          noResultsBehaviour: ['field_no_result_behaviour']
         },
         childCols: cardColsSetting
       },

--- a/packages/ripple-nuxt-tide/modules/landing-page/tide.middleware.js
+++ b/packages/ripple-nuxt-tide/modules/landing-page/tide.middleware.js
@@ -41,7 +41,7 @@ export default {
             key,
             promise: context.app.$tideSearchApi.search('/cards', {
               site: context.store.state.tideSite.siteId,
-              ...getQueryParams(component.data.config)
+              ...getQueryParams(component.data)
             })
           })
         }
@@ -56,7 +56,6 @@ export default {
           component.data.initialResults = response.results
           component.data.total = response.total
           component.data.sidebar = pageData.tideLayout.sidebar
-          component.data.config.results.min_not_met = 'no_results_message'
         })
       }
     }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SW-1635

### Changed

1. Migrate patch from solar website: https://github.com/dpc-sdp/solar-vic-gov-au/blob/develop/patches/%40dpc-sdp%2Bripple-nuxt-tide%2B1.29.2.patch
2. Update to card collection to address the following:
    * Custom no results message not displaying
    * Results not hidden when minimum number of cards isn't meet
    * Component isn't hidden when minimum number of cards isn't meet and hide component is set
    
For reference, the deprecated drupal fields: https://github.com/dpc-sdp/tide_automated_listing/blob/dda418f23871f2c4a1cf1ef25a71d442a1f28da3/src/Plugin/Field/FieldWidget/AutomatedListingConfigurationWidgetEnhanced.php#L541

### Testing
Compare the display of the following develop page vs the same page on the PR branch.

**Develop**: https://www.develop.solar.vic.gov.au/test-events-collection
**PR**: https://app.pr-89.solar-vic-gov-au.sdp4.sdp.vic.gov.au/test-events-collection

### Screenshot of develop branch
![develop-site](https://user-images.githubusercontent.com/287178/187578385-07c15f8b-33d5-496d-a43c-35b2cc5da0f0.png)

### Screenshot of PR branch
![pr-branch](https://user-images.githubusercontent.com/287178/187579292-a8f45d28-f0d6-42ee-b18f-5cbed22547fe.png)
