### PR TITLE
[DDS-1368] Removed reference site hostnames from ripple project.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -23,20 +23,10 @@ environments:
             tls-acme: 'false'
             insecure: Allow
             hsts: max-age=31536000
-      - app:
-        - "www.master.reference.sdp.vic.gov.au":
-            tls-acme: 'false'
-            insecure: Allow
-            hsts: max-age=31536000
   develop:
     routes:
       - storybook:
         - "www.develop.ripple.sdp.vic.gov.au":
-            tls-acme: 'false'
-            insecure: Allow
-            hsts: max-age=31536000
-      - app:
-        - "www.develop.reference.sdp.vic.gov.au":
             tls-acme: 'false'
             insecure: Allow
             hsts: max-age=31536000


### PR DESCRIPTION
Removes reference site hostnames from .lagoon.yml so they can be added to the actual reference site.