### PR TITLE
Specify Nuxt v3 in the readmes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Check out our example Vue.js app: [Vue app example](https://github.com/dpc-sdp/r
 
 #### Use Ripple in Nuxt.js(SSR) app
 
-For users are using Nuxt.js. You can use our Nuxt module [@dpc-sdp/ripple-nuxt-ui](https://www.npmjs.com/package/@dpc-sdp/ripple-nuxt-ui) to add Ripple components library to your project. This configures `@dpc-sdp/ripple-global` and adds required webpack config.
+For users are using Nuxt.js v3. You can use our Nuxt module [@dpc-sdp/ripple-nuxt-ui](https://www.npmjs.com/package/@dpc-sdp/ripple-nuxt-ui) to add Ripple components library to your project. This configures `@dpc-sdp/ripple-global` and adds required webpack config.
 
 Please see [@dpc-sdp/ripple-nuxt-ui](https://github.com/dpc-sdp/ripple/blob/master/packages/ripple-nuxt-ui/README.md) for details.
 

--- a/packages/ripple-nuxt-ui/README.md
+++ b/packages/ripple-nuxt-ui/README.md
@@ -16,7 +16,7 @@ soon.
 
 ### Option 2. Adding to existing Nuxt project
 
-Without using `create-nuxt-app`, you can setup it in your existing Nuxt site with
+Without using `create-nuxt-app`, you can setup it in your existing Nuxt (v3) site with
 following steps.
 
 #### Add `@dpc-sdp/ripple-nuxt-ui` dependency using yarn or npm to your project


### PR DESCRIPTION
I could only use the nuxt module `@dpc-sdp/ripple-ui-core/nuxt` in a Nuxt v3 app - in Nuxt v2, I got the following error:

`Error: Cannot use import outside of a module`

This PR just adds 'v3' where in the readme sections mentioning adding to an existing Nuxt app.