### PR TITLE
Updated nightwatch workflow inputs and added Estuary app to trigger workflow

### DIFF
--- a/.github/workflows/nightwatch.yml
+++ b/.github/workflows/nightwatch.yml
@@ -5,12 +5,12 @@ on:
       e2e:
         type: boolean
         required: true
-      e2e_project:
+      project:
         type: string
         required: true
-      e2e_be_url:
+      be_url:
         type: string
-      e2e_fe_url:
+      fe_url:
         type: string
 jobs:
   e2e_be:
@@ -18,9 +18,9 @@ jobs:
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_be.yml@main
     secrets: inherit
     with:
-      tags: "(@core or @${{ inputs.e2e_project }}) and @regression"
-      be_url: ${{ inputs.e2e_be_url }}
-      project: ${{ inputs.e2e_project }}
+      tags: "(@core or @${{ inputs.project }}) and @regression"
+      be_url: ${{ inputs.be_url }}
+      project: ${{ inputs.project }}
       browser: 'chrome'
       test_id: 'fixture'
       test_type: ':nightwatch:'
@@ -30,10 +30,10 @@ jobs:
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_fe.yml@main
     secrets: inherit
     with:
-      tags: "(@smoke and @core) or (@smoke and @${{ inputs.e2e_project }})"
-      be_url: ${{ inputs.e2e_be_url }}
-      fe_url: ${{ inputs.e2e_fe_url }}
-      project: ${{ inputs.e2e_project }}
+      tags: "(@smoke and @core) or (@smoke and @${{ inputs.project }})"
+      be_url: ${{ inputs.be_url }}
+      fe_url: ${{ inputs.fe_url }}
+      project: ${{ inputs.project }}
       browser: 'chrome'
       test_id: 'fixture'
       test_type: ':nightwatch:'
@@ -46,10 +46,10 @@ jobs:
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_fe.yml@main
     secrets: inherit
     with:
-      tags: "(@core or @${{ inputs.e2e_project }}) and @regression and not @mobile"
-      be_url: ${{ inputs.e2e_be_url }}
-      fe_url: ${{ inputs.e2e_fe_url }}
-      project: ${{ inputs.e2e_project }}
+      tags: "(@core or @${{ inputs.project }}) and @regression and not @mobile"
+      be_url: ${{ inputs.be_url }}
+      fe_url: ${{ inputs.fe_url }}
+      project: ${{ inputs.project }}
       browser: 'chrome'
       test_id: 'fixture'
       test_type: ':nightwatch:'
@@ -62,10 +62,10 @@ jobs:
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_fe.yml@main
     secrets: inherit
     with:
-      tags: "(@core or @${{ inputs.e2e_project }}) and @regression and not @desktop"
-      be_url: ${{ inputs.e2e_be_url }}
-      fe_url: ${{ inputs.e2e_fe_url }}
-      project: ${{ inputs.e2e_project }}
+      tags: "(@core or @${{ inputs.project }}) and @regression and not @desktop"
+      be_url: ${{ inputs.be_url }}
+      fe_url: ${{ inputs.fe_url }}
+      project: ${{ inputs.project }}
       browser: 'androidChrome'
       test_id: 'fixture'
       test_type: ':nightwatch:'

--- a/.github/workflows/nightwatch.yml
+++ b/.github/workflows/nightwatch.yml
@@ -2,9 +2,6 @@ name: dpc-sdp/ripple/nightwatch
 on:
   workflow_dispatch:
     inputs:
-      e2e:
-        type: boolean
-        required: true
       project:
         type: string
         required: true
@@ -14,7 +11,6 @@ on:
         type: string
 jobs:
   e2e_be:
-    if: inputs.e2e
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_be.yml@main
     secrets: inherit
     with:
@@ -26,7 +22,6 @@ jobs:
       test_type: ':nightwatch:'
       runner: 'ubuntu-latest'
   e2e_fe_smoke:
-    if: inputs.e2e
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_fe.yml@main
     secrets: inherit
     with:
@@ -42,7 +37,6 @@ jobs:
     needs:
       - e2e_be
       - e2e_fe_smoke
-    if: inputs.e2e
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_fe.yml@main
     secrets: inherit
     with:
@@ -58,7 +52,6 @@ jobs:
     needs:
       - e2e_be
       - e2e_fe_smoke
-    if: inputs.e2e
     uses: dpc-sdp/github-actions/.github/workflows/run_e2e_fe.yml@main
     secrets: inherit
     with:

--- a/scripts/trigger-e2e.sh
+++ b/scripts/trigger-e2e.sh
@@ -45,20 +45,20 @@ else
     }'
 fi
 
-if [ -z $E2E_ESTUARY_URL ]; then
-  echo "Error: No E2E Estuary URL found, end to end is not triggered. Please make sure E2E_ESTUARY_URL is set up."
+if [ -z $E2E_ESTUARY_URL ] || [ -z $E2E_ESTUARY_TOKEN_PATH ]; then
+  echo "Error: No Estuary URL or token path found, end to end is not triggered. Please make sure E2E_ESTUARY_URL and E2E_ESTUARY_TOKEN_PATH are set up."
 else
   # Trigger GitHub Action to run the nightwatch workflow via estuary
-  curl --location --request POST "$E2E_ESTUARY_URL" \
-    --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccount/token)" \
-    --header "Content-Type: application/json" \
-    --data-raw '{
-      "owner": "dpc-sdp",
-      "repo": "ripple",
-      "workflow": "nightwatch.yml",
-      "ref": "'"$BRANCH"'",
-      "be_url": "'"$BE_URL"'",
-      "fe_url": "'"$FE_URL"'",
-      "project": "reference"
-    }'
+curl --location --request POST "$E2E_ESTUARY_URL" \
+  --header "Authorization: Bearer $(cat $E2E_ESTUARY_TOKEN_PATH)" \
+  --header "Content-Type: application/json" \
+  --data-raw '{
+    "owner": "dpc-sdp",
+    "repo": "ripple",
+    "workflow": "nightwatch.yml",
+    "ref": "'"$BRANCH"'",
+    "be_url": "'"$BE_URL"'",
+    "fe_url": "'"$FE_URL"'",
+    "project": "reference"
+  }'
 fi

--- a/scripts/trigger-e2e.sh
+++ b/scripts/trigger-e2e.sh
@@ -45,20 +45,18 @@ else
     }'
 fi
 
-if [ -z $E2E_ESTUARY_URL ] || [ -z $E2E_ESTUARY_TOKEN_PATH ]; then
-  echo "Error: No Estuary URL or token path found, end to end is not triggered. Please make sure E2E_ESTUARY_URL and E2E_ESTUARY_TOKEN_PATH are set up."
-else
-  # Trigger GitHub Action to run the nightwatch workflow via estuary
-  curl --location --request POST "$E2E_ESTUARY_URL" \
-    --header "Authorization: Bearer $(cat $E2E_ESTUARY_TOKEN_PATH)" \
-    --header "Content-Type: application/json" \
-    --data-raw '{
-      "owner": "dpc-sdp",
-      "repo": "ripple",
-      "workflow": "nightwatch.yml",
-      "ref": "'"$BRANCH"'",
-      "be_url": "'"$BE_URL"'",
-      "fe_url": "'"$FE_URL"'",
-      "project": "reference"
-    }'
-fi
+E2E_ESTUARY_URL="${E2E_ESTUARY_URL:-http://estuary.sdp-services:8080/v1/actions/trigger-e2e}"
+E2E_ESTUARY_TOKEN_PATH="${E2E_ESTUARY_TOKEN_PATH:-/run/secrets/kubernetes.io/serviceaccount/token}"
+# Trigger GitHub Action to run the nightwatch workflow via estuary
+curl --location --request POST "$E2E_ESTUARY_URL" \
+  --header "Authorization: Bearer $(cat $E2E_ESTUARY_TOKEN_PATH)" \
+  --header "Content-Type: application/json" \
+  --data-raw '{
+    "owner": "dpc-sdp",
+    "repo": "ripple",
+    "workflow": "nightwatch.yml",
+    "ref": "'"$BRANCH"'",
+    "be_url": "'"$BE_URL"'",
+    "fe_url": "'"$FE_URL"'",
+    "project": "reference"
+  }'

--- a/scripts/trigger-e2e.sh
+++ b/scripts/trigger-e2e.sh
@@ -49,16 +49,16 @@ if [ -z $E2E_ESTUARY_URL ] || [ -z $E2E_ESTUARY_TOKEN_PATH ]; then
   echo "Error: No Estuary URL or token path found, end to end is not triggered. Please make sure E2E_ESTUARY_URL and E2E_ESTUARY_TOKEN_PATH are set up."
 else
   # Trigger GitHub Action to run the nightwatch workflow via estuary
-curl --location --request POST "$E2E_ESTUARY_URL" \
-  --header "Authorization: Bearer $(cat $E2E_ESTUARY_TOKEN_PATH)" \
-  --header "Content-Type: application/json" \
-  --data-raw '{
-    "owner": "dpc-sdp",
-    "repo": "ripple",
-    "workflow": "nightwatch.yml",
-    "ref": "'"$BRANCH"'",
-    "be_url": "'"$BE_URL"'",
-    "fe_url": "'"$FE_URL"'",
-    "project": "reference"
-  }'
+  curl --location --request POST "$E2E_ESTUARY_URL" \
+    --header "Authorization: Bearer $(cat $E2E_ESTUARY_TOKEN_PATH)" \
+    --header "Content-Type: application/json" \
+    --data-raw '{
+      "owner": "dpc-sdp",
+      "repo": "ripple",
+      "workflow": "nightwatch.yml",
+      "ref": "'"$BRANCH"'",
+      "be_url": "'"$BE_URL"'",
+      "fe_url": "'"$FE_URL"'",
+      "project": "reference"
+    }'
 fi

--- a/scripts/trigger-e2e.sh
+++ b/scripts/trigger-e2e.sh
@@ -56,9 +56,9 @@ else
       "owner": "dpc-sdp",
       "repo": "ripple",
       "workflow": "nightwatch.yml",
-      "ref": "$BRANCH",
-      "be_url": "$BE_URL",
-      "fe_url": "$FE_URL",
+      "ref": "'"$BRANCH"'",
+      "be_url": "'"$BE_URL"'",
+      "fe_url": "'"$FE_URL"'",
       "project": "reference"
     }'
 fi

--- a/scripts/trigger-e2e.sh
+++ b/scripts/trigger-e2e.sh
@@ -45,20 +45,20 @@ else
     }'
 fi
 
-if [ -z $E2E_GITHUB_TOKEN ]; then
-  echo "Error: No E2E GitHub token found, end to end is not triggered. Please make sure E2E_GITHUB_TOKEN is set up."
+if [ -z $E2E_ESTUARY_URL ]; then
+  echo "Error: No E2E Estuary URL found, end to end is not triggered. Please make sure E2E_ESTUARY_URL is set up."
 else
-  # Trigger GitHub Action to run the workflow
-  curl --location --request POST "https://api.github.com/repos/dpc-sdp/ripple/actions/workflows/nightwatch.yml/dispatches" \
-    --header "Authorization: Bearer $E2E_GITHUB_TOKEN" \
-    --header 'Accept: application/vnd.github+json' \
+  # Trigger GitHub Action to run the nightwatch workflow via estuary
+  curl --location --request POST "$E2E_ESTUARY_URL" \
+    --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccount/token)" \
+    --header "Content-Type: application/json" \
     --data-raw '{
-        "ref": "'"$BRANCH"'",
-        "inputs": {
-            "e2e": true,
-            "e2e_be_url": "'"$BE_URL"'",
-            "e2e_fe_url": "'"$FE_URL"'",
-            "e2e_project": "reference"
-        }
+      "owner": "dpc-sdp",
+      "repo": "ripple",
+      "workflow": "nightwatch.yml",
+      "ref": "$BRANCH",
+      "be_url": "$BE_URL",
+      "fe_url": "$FE_URL",
+      "project": "reference"
     }'
 fi


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING.md BEFORE CREATING A PR

Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

No need to remove these lines - they are comments.
-->

## Changed

<!-- Describe your changes in detail -->

1. Updated the nightwatch workflow input names to match what the estuary API expects to send to the GitHub workflows.
https://github.com/dpc-sdp/estuary/blob/79da49c5866435436a14795c288fc8a9a2cceaa4/pkg/github/server.go#L53
2. Removed `E2E` input and logic
3. Updated `trigger-e2e.sh` script to use the Estuary app to trigger e2e testing.
