### PR TITLE
[SD-1651] fix button styling when anchor tag used

### DIFF
--- a/packages/ripple-ui-core/src/components/button/RplButton.css
+++ b/packages/ripple-ui-core/src/components/button/RplButton.css
@@ -18,6 +18,7 @@
     calc(var(--rpl-sp-5) - var(--local-border-width));
   width: 100%;
   appearance: none;
+  text-align: center;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1651

### What I did
<!-- Summary of changes made in the Pull Request -->
- text align: center is applied by the browser for <button>s, but is missing if the RplButton is an <a> tag
- 

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
