### PR TITLE
feat(@dpc-sdp/ripple-ui-core): add default slot to RplSearchResult

### DIFF
--- a/packages/ripple-ui-core/src/components/result-listing/RplResultListing.stories.ts
+++ b/packages/ripple-ui-core/src/components/result-listing/RplResultListing.stories.ts
@@ -29,6 +29,9 @@ const Template = (args: any) => ({
             <template v-if="args.details" #details>
               ${args.details}
             </template>
+            <template v-if="args.default">
+              ${args.default}
+            </template>
           </RplSearchResult>
         </RplResultListingItem>
       </RplResultListing>
@@ -100,5 +103,13 @@ export const WithNoDateLabel: Story = {
   args: {
     dateLabel: null,
     updated: 'Some custom text'
+  }
+}
+
+export const WithDefaultSlot: Story = {
+  args: {
+    content: null,
+    default:
+      '<p class="rpl-type-h3-highlight">Content rendered via the default slot.</p>'
   }
 }

--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
@@ -81,6 +81,7 @@ const handleClick = () => {
       class="rpl-search-result__body rpl-type-p"
       v-html="content"
     />
+    <slot />
     <p v-if="updated" class="rpl-search-result__date rpl-type-p-small">
       {{ dateLabel ? `${dateLabel}: ` : '' }}{{ updated }}
     </p>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1603

### What I did
<!-- Summary of changes made in the Pull Request -->
-  Add default slot to RplSearchResult component


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
