### PR TITLE
feat(@dpc-sdp/ripple-ui-maps): add excessResults prop to sidepanel

### DIFF
--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.vue
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.vue
@@ -15,6 +15,7 @@
             :pagingStart="pagingStart"
             :pagingEnd="pagingEnd"
             :totalResults="totalResults"
+            :excessResults="excessResults"
           />
         </slot>
       </div>
@@ -71,6 +72,7 @@ interface Props {
   totalPages: number
   currentPage: number
   listLabel?: string
+  excessResults?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -78,7 +80,8 @@ const props = withDefaults(defineProps<Props>(), {
   panelLocation: 'left',
   isStandalone: false,
   showToggle: false,
-  listLabel: 'Map search results'
+  listLabel: 'Map search results',
+  excessResults: false
 })
 
 const isOpen = ref(true)

--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanelCount.vue
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanelCount.vue
@@ -7,7 +7,7 @@
     >
       <p class="rpl-type-label-small">
         Displaying {{ pagingStart }}-{{ pagingEnd }} of {{ totalResults
-        }}{{ maxResultsExceededMarker }} results
+        }}{{ excessResultsMarker }} results
       </p>
     </slot>
   </div>
@@ -20,18 +20,12 @@ interface Props {
   pagingStart: number
   pagingEnd: number
   totalResults: number
-  maxResults?: number | null
+  excessResults?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  maxResults: null
+  excessResults: false
 })
 
-const maxResultsExceededMarker = computed(() => {
-  if (!props.maxResults) {
-    return ''
-  }
-
-  return props.totalResults >= props.maxResults ? '+' : ''
-})
+const excessResultsMarker = computed(() => (props.excessResults ? '+' : ''))
 </script>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1377

### What I did
<!-- Summary of changes made in the Pull Request -->
- Looks like the maxResultsExceededMarker i.e. showing the `+` has never actually worked on the maps sidepanel result count, this updates it to use excessResults and there's a related ripple framework PR to actually get this working.

<img width="652" height="186" alt="Screenshot 2026-04-28 at 11 11 32 am" src="https://github.com/user-attachments/assets/3f633d75-3bb7-4355-8cd3-b208740edd27" />

TEST URLs: 
https://app.pr-1361.vic-gov-au.sdp4.sdp.vic.gov.au/test-map
http://app.pr-1361.vic-gov-au.sdp4.sdp.vic.gov.au/test-map-2

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
