### PR TITLE
fix(@dpc-sdp/ripple-ui-core): vertical nav indentation

### DIFF
--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavList.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { IRplVerticalNavItem } from './constants'
 import RplVerticalNavLink from './RplVerticalNavLink.vue'
 import RplVerticalNavToggle from './RplVerticalNavToggle.vue'
@@ -25,15 +26,9 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-vertical-nav', emit)
 
-const showIcon = (index: number) => {
-  const hasIcon = props.level > Math.max(props.toggleLevels, 2)
-
-  if (index === 0 && props.level - 1 <= props.toggleLevels) {
-    return false
-  }
-
-  return hasIcon
-}
+const showIcon = computed(() => {
+  return props.level > props.toggleLevels + 1
+})
 
 const isExpandable = (item: IRplVerticalNavItem) => {
   return item.items && props.level <= props.toggleLevels
@@ -69,7 +64,7 @@ const handleClick = (event) => {
             :text="item.text"
             :href="item.url"
             :active="item?.active && !item.items?.some((i) => i.active)"
-            :show-child-icon="showIcon(index)"
+            :show-child-icon="showIcon"
             @item-click="(event) => handleClick(event)"
           />
           <RplVerticalNavToggle
@@ -98,7 +93,7 @@ const handleClick = (event) => {
           :text="item.text"
           :href="item.url"
           :active="item?.active && !item.items?.some((i) => i.active)"
-          :show-child-icon="showIcon(index)"
+          :show-child-icon="showIcon"
           @item-click="(event) => handleClick(event)"
         />
         <RplVerticalNavList

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavList.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavList.vue
@@ -27,7 +27,7 @@ const emit = defineEmits<{
 const { emitRplEvent } = useRippleEvent('rpl-vertical-nav', emit)
 
 const showIcon = computed(() => {
-  return props.level > props.toggleLevels + 1
+  return props.level > Math.max(1, props.toggleLevels) + 1
 })
 
 const isExpandable = (item: IRplVerticalNavItem) => {

--- a/packages/ripple-ui-core/src/components/vertical-nav/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/vertical-nav/fixtures/sample.ts
@@ -16,12 +16,27 @@ export const verticalNavExample1 = [
             url: '#',
             items: [
               {
-                id: '5',
+                id: '41',
                 text: 'Fourth level',
                 url: '#',
                 items: [{ id: '51', text: 'Fifth level', url: '#' }]
+              },
+              {
+                id: '42',
+                text: 'Fourth level item 2',
+                url: '#'
               }
             ]
+          },
+          {
+            id: '5',
+            text: 'Third level item 2',
+            url: '#'
+          },
+          {
+            id: '6',
+            text: 'Third level item 3',
+            url: '#'
           }
         ]
       },
@@ -153,6 +168,11 @@ export const verticalNavExample3 = [
                 text: 'Fourth level',
                 url: '#',
                 items: [{ id: '51', text: 'Fifth level', url: '#' }]
+              },
+              {
+                id: '6',
+                text: 'Fourth level item 2',
+                url: '#'
               }
             ]
           }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1774

### What I did
<!-- Summary of changes made in the Pull Request -->
- Update vertical nav indents, some menu items show as 'sub/indented' items even when they aren't


### How to test
<!-- Summary of how to test the changes -->

Reference menu: https://develop.content-vic.sdp.delivery/admin/structure/menu/manage/site-main-menu-vicgovau-protect
Current: https://develop.vic-gov-au.sdp.delivery/develop-school-child-safety-and-wellbeing-policy
Updated: https://app.pr-1383.vic-gov-au.sdp4.sdp.vic.gov.au/develop-school-child-safety-and-wellbeing-policy


<img width="1288" height="1258" alt="Screenshot 2026-06-09 at 4 57 59 pm" src="https://github.com/user-attachments/assets/ce8ba2c8-af7d-4fac-a63d-dd26c7bd97eb" />


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
