### PR TITLE
feat(@dpc-sdp/ripple-ui-core): left align button text on large screens

### DIFF
--- a/packages/ripple-ui-core/src/components/button/RplButton.css
+++ b/packages/ripple-ui-core/src/components/button/RplButton.css
@@ -32,6 +32,7 @@
 
   @media (--rpl-bp-s) {
     width: auto;
+    text-align: left;
   }
 
   &--reverse {

--- a/packages/ripple-ui-core/src/components/button/RplButton.stories.ts
+++ b/packages/ripple-ui-core/src/components/button/RplButton.stories.ts
@@ -8,6 +8,7 @@ import {
 } from './constants'
 import { RplIconNames } from '../icon/constants'
 import { buttonFocusState } from './RplButton.play'
+import { bpMin } from '../../lib/breakpoints'
 
 export default {
   title: 'Core/Navigation/Button',
@@ -153,4 +154,18 @@ export const BusyState: Story = {
     iconName: 'icon-exclamation-circle-filled',
     busy: true
   }
+}
+
+export const LongContent: Story = {
+  name: 'Example/Long content',
+  parameters: {
+    chromatic: {
+      viewports: [bpMin.s - 100, bpMin.l]
+    }
+  },
+  render: () => ({
+    template: `<div style="max-width: 576px">
+      <RplButton>This is certainly a lot of text for a little button, some might say too much</RplButton>
+    </div>`
+  })
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1767

### What I did
<!-- Summary of changes made in the Pull Request -->
- Left align button text on large screens

### How to test
<!-- Summary of how to test the changes -->
- https://5e736ff82649250022dd830c-qdkgjhcxdl.chromatic.com/?path=/story/core-navigation-button--long-content
- https://app.pr-1390.vic-gov-au.sdp4.sdp.vic.gov.au/clone-testing-page-analytics

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
