### PR TITLE
feat(@dpc-sdp/ripple-ui-core): left align header intro buttons

### DIFF
--- a/packages/ripple-ui-core/src/components/header/RplHeaderLinks.css
+++ b/packages/ripple-ui-core/src/components/header/RplHeaderLinks.css
@@ -50,6 +50,10 @@
   }
 }
 
+.rpl-header-links--button .rpl-header-links__item {
+  text-align: left;
+}
+
 .rpl-header-links__item .rpl-list__link {
   margin-right: calc(-1 * var(--rpl-sp-6));
   padding-right: var(--rpl-sp-6);


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1828

### What I did
<!-- Summary of changes made in the Pull Request -->
- This just left aligns header intro button text so it doesn't look misaligned like below

<img width="1155" height="487" alt="image-20260708-014514" src="https://github.com/user-attachments/assets/6aa59d32-8c1e-4995-be0f-acd48a2c2825" />


### How to test
<!-- Summary of how to test the changes -->
- https://app.pr-1390.vic-gov-au.sdp4.sdp.vic.gov.au/clone-testing-page-analytics

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
