### PR TITLE
feat(@dpc-sdp/ripple-ui-forms): add default values for injects

### DIFF
--- a/packages/ripple-ui-forms/src/components/RplFormActions/RplFormActions.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormActions/RplFormActions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { reset } from '@formkit/vue'
-import { computed, inject, onMounted } from 'vue'
+import { computed, inject, onMounted, ref } from 'vue'
 import { useRippleEvent } from '@dpc-sdp/ripple-ui-core'
 import type { rplEventPayload } from '@dpc-sdp/ripple-ui-core'
 import { getCaptchaElementId } from '../../utils/getCaptchaElementId'
@@ -50,12 +50,13 @@ const iconPosition = computed(() => {
   return undefined
 })
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 const onCaptchaElementReady: (() => void) | undefined = inject(
-  'onCaptchaElementReady'
+  'onCaptchaElementReady',
+  undefined
 )
-const isFormSubmitting: any = inject('isFormSubmitting')
-const onFormReset = inject('onFormReset')
+const isFormSubmitting: any = inject('isFormSubmitting', ref(false))
+const onFormReset = inject('onFormReset', undefined)
 
 const handleReset = () => {
   if (typeof onFormReset === 'function') {

--- a/packages/ripple-ui-forms/src/components/RplFormAutocomplete/RplFormAutocomplete.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormAutocomplete/RplFormAutocomplete.vue
@@ -72,7 +72,7 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-form-autocomplete', emit)
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 
 const internalInputValue = ref<string | string[]>('')
 const containerRef = ref(null)

--- a/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.vue
@@ -78,7 +78,7 @@ const emit = defineEmits<{
   ): void
 }>()
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 
 const { emitRplEvent } = useRippleEvent('rpl-form-dropdown', emit)
 

--- a/packages/ripple-ui-forms/src/components/RplFormFile/RplFormFile.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormFile/RplFormFile.vue
@@ -82,7 +82,7 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-form-file', emit)
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 
 const emitUpdate = () => {
   const uploadedFiles = internalFiles.value

--- a/packages/ripple-ui-forms/src/components/RplFormInput/RplFormInput.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormInput/RplFormInput.vue
@@ -66,7 +66,7 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-form-input', emit)
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 
 const classes = computed(() => {
   return {

--- a/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.vue
@@ -64,7 +64,7 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-form-number', emit)
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 
 const classes = computed(() => {
   return {

--- a/packages/ripple-ui-forms/src/components/RplFormOptionButtons/RplFormOptionButtons.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormOptionButtons/RplFormOptionButtons.vue
@@ -38,7 +38,7 @@ const emit = defineEmits<{
   (e: 'update', payload: rplEventPayload & { action: 'update' }): void
 }>()
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 const { emitRplEvent } = useRippleEvent('rpl-form-option-buttons', emit)
 
 const handleChange = (selectedId: string) => {

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.vue
@@ -40,7 +40,7 @@ const emit = defineEmits<{
   (e: 'update', payload: rplEventPayload & { action: 'update' }): void
 }>()
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 const { emitRplEvent } = useRippleEvent('rpl-form-checkbox-group', emit)
 
 const handleToggle = (selectedValue: string) => {

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormOption.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormOption.vue
@@ -50,7 +50,7 @@ const emit = defineEmits<{
 }>()
 
 const isMounted = ref(false)
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 const { emitRplEvent } = useRippleEvent('rpl-form-option', emit)
 
 const classes = computed(() => {

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormRadioGroup.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormRadioGroup.vue
@@ -40,7 +40,7 @@ const emit = defineEmits<{
   (e: 'update', payload: rplEventPayload & { action: 'update' }): void
 }>()
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 const { emitRplEvent } = useRippleEvent('rpl-form-radio-group', emit)
 
 const handleChange = (selectedValue: string) => {

--- a/packages/ripple-ui-forms/src/components/RplFormStep/RplFormStep.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormStep/RplFormStep.vue
@@ -93,11 +93,13 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const { focusFormElement } = useFormFocus()
-const formEl: IRplFormProvidedState | undefined = inject('form')
+const formEl: IRplFormProvidedState = inject('form', {})
 
 const stepErrorsRef = ref(null)
-const inputErrors: Ref<Record<string, string[]>> | undefined =
-  inject('inputErrors')
+const inputErrors: Ref<Record<string, string[]>> | undefined = inject(
+  'inputErrors',
+  ref({})
+)
 
 const handleBack = () => getNode(props.form)?.previous()
 

--- a/packages/ripple-ui-forms/src/components/RplFormTextarea/RplFormTextarea.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormTextarea/RplFormTextarea.vue
@@ -40,7 +40,7 @@ const emit = defineEmits<{
   (e: 'update', payload: rplEventPayload & { action: 'update' }): void
 }>()
 
-const form: IRplFormProvidedState | undefined = inject('form')
+const form: IRplFormProvidedState = inject('form', {})
 
 const { emitRplEvent } = useRippleEvent('rpl-form-textarea', emit)
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://github.com/dpc-sdp/ripple/issues/1397

### What I did
<!-- Summary of changes made in the Pull Request -->
- Set defaults for all uses of `inject` in `rpl-ui-forms` to avoid warnings like "form not found" and "onCaptchaElementReady not found", see: https://github.com/dpc-sdp/ripple/issues/1397

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
