### PR TITLE
feat(@dpc-sdp/ripple-ui-core): allow customizing the gap between slides

### DIFF
--- a/packages/ripple-ui-core/src/components/slider/RplSlider.vue
+++ b/packages/ripple-ui-core/src/components/slider/RplSlider.vue
@@ -2,7 +2,7 @@
 import { computed, ref, useSlots, watch, onMounted } from 'vue'
 import RplPagination from '../pagination/RplPagination.vue'
 import { bpMin } from '../../lib/breakpoints'
-import { RplSlidesPerView } from './constants'
+import { RplSlideGap, RplSlidesPerView } from './constants'
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import { EffectFade } from 'swiper/modules'
 import { useBreakpoints } from '@vueuse/core'
@@ -25,6 +25,7 @@ interface Props {
   itemElement?: string
   wrapperElement?: string
   changeNotice?: boolean | string
+  slideGap?: RplSlideGap
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -37,7 +38,8 @@ const props = withDefaults(defineProps<Props>(), {
   contentType: 'item',
   itemElement: 'li',
   wrapperElement: 'ul',
-  changeNotice: true
+  changeNotice: true,
+  slideGap: undefined
 })
 
 const emit = defineEmits<{
@@ -58,7 +60,7 @@ const isXSmallScreen = bp.greaterOrEqual('xs')
 const isSmallScreen = bp.greaterOrEqual('s')
 const isMediumScreen = bp.greaterOrEqual('m')
 const isLargeScreen = bp.greaterOrEqual('l')
-const isXLargeScreen = bp.greaterOrEqual('l')
+const isXLargeScreen = bp.greaterOrEqual('xl')
 
 const slides = computed(
   () => slots?.default?.()?.[0].children || slots?.default?.() || []
@@ -109,12 +111,18 @@ const breakpoints = computed(() => {
 })
 
 const spaceBetween = computed(() => {
-  if (isXLargeScreen.value) {
-    return 28
+  if (typeof props.slideGap === 'number') {
+    return props.slideGap
+  } else if (isXLargeScreen.value) {
+    return props.slideGap?.xl ?? 28
+  } else if (isLargeScreen.value) {
+    return props.slideGap?.l ?? 28
   } else if (isMediumScreen.value) {
-    return 24
+    return props.slideGap?.m ?? 24
+  } else if (isSmallScreen.value) {
+    return props.slideGap?.s ?? 16
   } else {
-    return 16
+    return props.slideGap?.xs ?? 16
   }
 })
 

--- a/packages/ripple-ui-core/src/components/slider/constants.ts
+++ b/packages/ripple-ui-core/src/components/slider/constants.ts
@@ -1,3 +1,5 @@
 import { RplBreakpoints } from '../../lib/breakpoints'
 
 export type RplSlidesPerView = RplBreakpoints | number | undefined
+
+export type RplSlideGap = RplBreakpoints | number | undefined


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1845

### What I did
<!-- Summary of changes made in the Pull Request -->
- Allow customizing the gap between slides

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
