### PR TITLE
feat(@dpc-sdp/ripple-ui-core): allow mixing link/toggles with just toggles

### DIFF
--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.css
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.css
@@ -163,6 +163,16 @@
   .rpl-vertical-nav__list-item--expanded > .rpl-vertical-nav__header > & .rpl-icon {
     transform: rotate(-180deg);
   }
+
+  &.rpl-vertical-nav__item {
+    padding-left: calc(var(--local-v-nav-gutter) + var(--local-left-indentation));
+    position: relative !important;
+    inset: auto;
+
+    span {
+      padding-right: 0;
+    }
+  }
 }
 
 .rpl-vertical-nav__toggle-text {

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.cy.ts
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.cy.ts
@@ -2,7 +2,8 @@ import RplVerticalNav from './RplVerticalNav.vue'
 import {
   verticalNavExample1,
   verticalNavExample2,
-  verticalNavExample3
+  verticalNavExample3,
+  verticalNavExample5
 } from './fixtures/sample'
 
 const props = {
@@ -149,5 +150,37 @@ describe('RplVerticalNav', () => {
         .find('.rpl-vertical-nav__list--level-2')
         .should('be.hidden')
     })
+  })
+
+  it('allows for mixing toggle with and without links', () => {
+    cy.mount(RplVerticalNav as any, {
+      props: { ...props, items: verticalNavExample5, toggleLevels: 2 }
+    })
+
+    cy.contains('.rpl-vertical-nav__link', 'First level with link').should(
+      'be.visible'
+    )
+    cy.get('[aria-label="Toggle First level with link menu"]').click()
+
+    cy.contains('.rpl-vertical-nav__link', 'Second level no link').should(
+      'not.exist'
+    )
+    cy.get('[aria-label="Toggle Second level no link menu"]').click()
+    cy.contains('.rpl-vertical-nav__link', 'Third level link in item 1').should(
+      'be.visible'
+    )
+
+    cy.contains('.rpl-vertical-nav__link', 'First level no link').should(
+      'not.exist'
+    )
+    cy.get('[aria-label="Toggle First level no link menu"]').click()
+
+    cy.contains('.rpl-vertical-nav__link', 'Second level with link').should(
+      'be.visible'
+    )
+    cy.get('[aria-label="Toggle Second level with link menu"]').click()
+    cy.contains('.rpl-vertical-nav__link', 'Third level in item 2').should(
+      'be.visible'
+    )
   })
 })

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.stories.ts
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.stories.ts
@@ -3,7 +3,8 @@ import RplVerticalNav from './RplVerticalNav.vue'
 import {
   verticalNavExample1,
   verticalNavExample3,
-  verticalNavExample4
+  verticalNavExample4,
+  verticalNavExample5
 } from './fixtures/sample'
 
 export default {
@@ -60,5 +61,13 @@ export const VerticalNavigationWithNoChildren: Story = {
   args: {
     title: 'Section name',
     items: verticalNavExample4
+  }
+}
+
+export const VerticalNavigationMixedToggles: Story = {
+  args: {
+    title: 'Section name',
+    items: verticalNavExample5,
+    toggleLevels: 2
   }
 }

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavList.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavList.vue
@@ -61,6 +61,7 @@ const handleClick = (event) => {
       <template v-if="isExpandable(item)">
         <div class="rpl-vertical-nav__header">
           <RplVerticalNavLink
+            v-if="item.url"
             :text="item.text"
             :href="item.url"
             :active="item?.active && !item.items?.some((i) => i.active)"
@@ -70,6 +71,7 @@ const handleClick = (event) => {
           <RplVerticalNavToggle
             :id="toggleId(item.id)"
             :text="item.text"
+            :show-text="!item.url"
             :aria-expanded="isExpanded(item.id)"
             @click="toggleItem(item)"
           />

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavToggle.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavToggle.vue
@@ -3,16 +3,27 @@ import RplIcon from '../icon/RplIcon.vue'
 
 interface Props {
   text: string
+  showText?: boolean
 }
-defineProps<Props>()
+
+withDefaults(defineProps<Props>(), {
+  showText: false
+})
 </script>
 
 <template>
   <button
     type="button"
     :aria-label="`Toggle ${text} menu`"
-    class="rpl-vertical-nav__toggle rpl-u-focusable-block"
+    :class="{
+      'rpl-vertical-nav__toggle': true,
+      'rpl-u-focusable-block': true,
+      'rpl-vertical-nav__item': showText
+    }"
   >
+    <span v-if="showText" class="rpl-vertical-nav__toggle-text">
+      {{ text }}
+    </span>
     <span class="rpl-vertical-nav__toggle-icon" aria-hidden="true">
       <RplIcon name="icon-chevron-down" size="xs"></RplIcon>
     </span>

--- a/packages/ripple-ui-core/src/components/vertical-nav/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/vertical-nav/fixtures/sample.ts
@@ -231,3 +231,67 @@ export const verticalNavExample4 = [
     ]
   }
 ]
+
+export const verticalNavExample5 = [
+  {
+    id: '1',
+    text: 'First level with link',
+    url: '#',
+    items: [
+      {
+        id: '3',
+        text: 'Second level no link',
+        items: [
+          {
+            id: '4',
+            text: 'Third level link in item 1',
+            url: '#',
+            items: [
+              {
+                id: '41',
+                text: 'Fourth level item 1',
+                url: '#'
+              },
+              {
+                id: '42',
+                text: 'Fourth level item 2',
+                url: '#'
+              }
+            ]
+          },
+          {
+            id: '5',
+            text: 'Third level item 2',
+            url: '#'
+          },
+          {
+            id: '6',
+            text: 'Third level item 3',
+            url: '#'
+          }
+        ]
+      },
+      { id: '7', text: 'Second level', url: '#' }
+    ]
+  },
+  {
+    id: '8',
+    text: 'First level no link',
+    items: [
+      {
+        id: '10',
+        text: 'Second level with link',
+        url: '#',
+        items: [
+          {
+            id: '11',
+            text: 'Third level in item 2',
+            url: '#'
+          }
+        ]
+      },
+      { id: '13', text: 'Second level item 2', url: '#' }
+    ]
+  },
+  { id: '15', text: 'First level no children', url: '#' }
+]


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1845

### What I did
<!-- Summary of changes made in the Pull Request -->
Allow mixing link/toggles with just toggles. Right now if a parent item doesn't have a link clicking the item won't do anything, with this update the whole item becomes a toggle when there is no link. So for example you could have a parent item 'Profiles' that was just a toggle with the actual profile links underneath.


### How to test
<!-- Summary of how to test the changes -->
- See storybook

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [x] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
